### PR TITLE
Station update fix

### DIFF
--- a/system/scripts/update-station.sh
+++ b/system/scripts/update-station.sh
@@ -13,8 +13,10 @@ dir="$home/sensor-station-software"
 if [ -d $dir ]; then
   # directory exists - stash any changes and do a git pull
   cd $dir
+  git config --global --add safe.directory $dir
   git stash
   git pull
+  sudo chown -R ctt $dir
   # checking if package.json has changed
   changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)" 
   check_run package.json "npm install"

--- a/system/scripts/update-station.sh
+++ b/system/scripts/update-station.sh
@@ -13,9 +13,12 @@ dir="$home/sensor-station-software"
 if [ -d $dir ]; then
   # directory exists - stash any changes and do a git pull
   cd $dir
+  echo $dir
+  git config --global --add safe.directory /usr/lib/ctt/sensor-station-software
   git config --global --add safe.directory $dir
   git stash
   git pull
+  sudo chown -R ctt $dir
   sudo chown -R ctt $dir
   # checking if package.json has changed
   changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)" 

--- a/system/scripts/update-station.sh
+++ b/system/scripts/update-station.sh
@@ -13,12 +13,9 @@ dir="$home/sensor-station-software"
 if [ -d $dir ]; then
   # directory exists - stash any changes and do a git pull
   cd $dir
-  echo $dir
   git config --global --add safe.directory /usr/lib/ctt/sensor-station-software
-  git config --global --add safe.directory $dir
   git stash
   git pull
-  sudo chown -R ctt $dir
   sudo chown -R ctt $dir
   # checking if package.json has changed
   changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)" 

--- a/system/scripts/update-station.sh
+++ b/system/scripts/update-station.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-home='/lib/ctt'
+home='/usr/lib/ctt'
+user_perm='ctt:ctt'
 sudo mkdir -p $home
 cd $home
 git_url='https://github.com/cellular-tracking-technologies/sensor-station-software.git'
@@ -9,14 +10,17 @@ check_run() {
 }
 
 dir="$home/sensor-station-software"
+# change permissions to ctt user to be safe
+sudo chown -R $user_perm $dir
 # check if the software directory exists
 if [ -d $dir ]; then
   # directory exists - stash any changes and do a git pull
   cd $dir
-  git config --global --add safe.directory /usr/lib/ctt/sensor-station-software
+  git config --global --add safe.directory $dir
   git stash
   git pull
-  sudo chown -R ctt $dir
+  # change permissions to ctt user after pull to be sure all files have same permissions
+  sudo chown -R $user_perm $dir
   # checking if package.json has changed
   changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)" 
   check_run package.json "npm install"
@@ -45,9 +49,13 @@ echo '********************'
 
 # pull sensorgnome code updates
 dir="$home/sensorgnome/sensorgnome"
+# change user permissions of sensorgnome directory to be safe
+sudo chown -R $user_perm $dir
 cd $dir
 git stash
 git pull
+sudo chown -R $user_perm $dir
+git config --global --add safe.directory $dir
 changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)" 
 check_run package.json "npm install"
 sudo systemctl restart sensorgnome


### PR DESCRIPTION
Attempt to address 'usafe repository' error when users try to update their station.

1. Added repository to the safe.directory using: `git config --global --add safe.directory /usr/lib/ctt/sensor-station-software`
2. Changed ownership back to ctt using: `sudo chown -R ctt $dir`