### PR TITLE
fix(usb): resolve USB download failures and add progress feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ v2_modem_fix.sh
 eslintrc.json
 src/station-interface/public/javascripts/data.json
 *.db
+ctt-usb-download-patch.zip
+usb-update-package/*

--- a/src/station-hardware-server/routes/usb.js
+++ b/src/station-hardware-server/routes/usb.js
@@ -7,9 +7,23 @@ import command from '../../command.js'
 const router = express.Router()
 
 const usb = new UsbStorage()
+const USB_MOUNT_POINT = '/mnt/usb'
+
+// total ceiling on any single copy operation. If ncp hasn't called back by
+// then, the watchdog forces the in-progress flag clear so the station can
+// recover without a service restart.
+const COPY_TOTAL_DEADLINE_MS = 20 * 60 * 1000
+// inactivity watchdog. If `copied` hasn't increased in this many ms, declare
+// the copy stalled and abort. Catches ncp callback races (e.g. when a source
+// file rotates out from under the walk).
+const COPY_STALL_MS = 5 * 60 * 1000
+// how often the stall watchdog samples the file count.
+const COPY_PROGRESS_SAMPLE_MS = 30 * 1000
+
 let mountInProgress = false
 let copyInProgress = false
-let copyProgress = { total: 0, baselineFiles: 0 }
+let copySession = 0
+let copyProgress = { total: 0, baselineFiles: 0, lastCopiedCount: 0, lastIncreaseAt: 0 }
 
 function countFiles(dir) {
   let count = 0
@@ -24,6 +38,15 @@ function countFiles(dir) {
     }
   } catch (e) { /* directory may not exist yet */ }
   return count
+}
+
+// true iff /mnt/usb is a real mountpoint (different filesystem from /mnt).
+function isUsbMounted() {
+  try {
+    return fs.statSync(USB_MOUNT_POINT).dev !== fs.statSync('/mnt').dev
+  } catch (e) {
+    return false
+  }
 }
 
 /* GET home page. */
@@ -89,6 +112,15 @@ router.get('/data/progress', (req, res) => {
 
 /**
  * copy data files from station to USB
+ *
+ * Guarded by three watchdogs:
+ *   1. mountpoint precheck — refuse to start if /mnt/usb isn't actually mounted
+ *   2. stall watchdog       — abort if `copied` doesn't increase for COPY_STALL_MS
+ *   3. total deadline       — abort if the operation exceeds COPY_TOTAL_DEADLINE_MS
+ *
+ * Each copy is tagged with a `mySession` token; late ncp callbacks from a
+ * watchdog-aborted copy are no-ops (they would otherwise stomp on a newer
+ * copy's module-level state).
  */
 router.get('/data', (req, res, next) => {
   if (copyInProgress) {
@@ -96,21 +128,88 @@ router.get('/data', (req, res, next) => {
     res.json({ status: "busy" })
     return
   }
+  if (!isUsbMounted()) {
+    console.log(`hardware-server USB data copy refused — ${USB_MOUNT_POINT} is not mounted`)
+    res.json({ status: "no-mount" })
+    return
+  }
+
   copyInProgress = true
+  const mySession = ++copySession
   copyProgress.total = countFiles("/data")
-  copyProgress.baselineFiles = countFiles("/mnt/usb")
-  req.setTimeout(1000 * 60 * 10) // set a 10 minute timeout for the usb transfer process to complete
+  copyProgress.baselineFiles = countFiles(USB_MOUNT_POINT)
+  copyProgress.lastCopiedCount = 0
+  copyProgress.lastIncreaseAt = Date.now()
+  // leave the watchdogs to fire first; HTTP socket gets a little extra slack.
+  req.setTimeout(COPY_TOTAL_DEADLINE_MS + 60 * 1000)
   const startTime = Date.now()
   console.log(`hardware-server USB data copy started from /data to USB (${copyProgress.total} files)`)
+
+  let responseSent = false
+  const sendOnce = (body) => {
+    if (responseSent) return
+    responseSent = true
+    res.json(body)
+  }
+
+  // Tear down module-level state for *this* session only. A watchdog-aborted
+  // copy whose ncp callback arrives late will see mySession !== copySession
+  // and bail before reaching this branch.
+  const finish = (body) => {
+    if (mySession === copySession) {
+      clearInterval(stallInterval)
+      clearTimeout(totalDeadline)
+      copyInProgress = false
+    }
+    sendOnce(body)
+  }
+
+  // When a watchdog aborts, ncp is still running in the background and will
+  // keep writing to /mnt/usb. Unmounting forces those writes to fail, which
+  // typically convinces ncp to release file handles and call its callback.
+  const abortByUnmount = (reason) => {
+    usb.unmount()
+      .then(() => console.log(`hardware-server unmounted ${USB_MOUNT_POINT} after ${reason}`))
+      .catch((err) => console.log(`hardware-server unmount-after-${reason} failed:`, err.message || err))
+  }
+
+  const stallInterval = setInterval(() => {
+    if (mySession !== copySession) return
+    const copied = Math.max(countFiles(USB_MOUNT_POINT) - copyProgress.baselineFiles, 0)
+    if (copied > copyProgress.lastCopiedCount) {
+      copyProgress.lastCopiedCount = copied
+      copyProgress.lastIncreaseAt = Date.now()
+      return
+    }
+    if (Date.now() - copyProgress.lastIncreaseAt > COPY_STALL_MS) {
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+      console.log(`hardware-server USB data copy stalled at ${copied}/${copyProgress.total} after ${elapsed}s — aborting`)
+      finish({ status: "stalled", copied, total: copyProgress.total })
+      abortByUnmount('stall')
+    }
+  }, COPY_PROGRESS_SAMPLE_MS)
+
+  const totalDeadline = setTimeout(() => {
+    if (mySession !== copySession) return
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+    console.log(`hardware-server USB data copy exceeded ${COPY_TOTAL_DEADLINE_MS / 1000}s deadline after ${elapsed}s — aborting`)
+    finish({ status: "timeout" })
+    abortByUnmount('timeout')
+  }, COPY_TOTAL_DEADLINE_MS)
+
   usb.copyTo("/data", /.*$/, (err) => {
-    copyInProgress = false
+    if (mySession !== copySession) {
+      // a watchdog already aborted this session; ignore the late callback
+      console.log('hardware-server USB data copy late callback (watchdog already aborted) — ignoring')
+      return
+    }
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
     if (err) {
       console.log(`hardware-server USB data copy failed after ${elapsed}s`, err)
-      res.json(fail)
+      finish(fail)
     } else {
       console.log(`hardware-server USB data copy completed successfully in ${elapsed}s`)
-      res.json(success)
+      finish(success)
     }
   })
 })

--- a/src/station-hardware-server/routes/usb.js
+++ b/src/station-hardware-server/routes/usb.js
@@ -7,6 +7,24 @@ import command from '../../command.js'
 const router = express.Router()
 
 const usb = new UsbStorage()
+let mountInProgress = false
+let copyInProgress = false
+let copyProgress = { total: 0, baselineFiles: 0 }
+
+function countFiles(dir) {
+  let count = 0
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isFile()) {
+        count++
+      } else if (entry.isDirectory()) {
+        count += countFiles(`${dir}/${entry.name}`)
+      }
+    }
+  } catch (e) { /* directory may not exist yet */ }
+  return count
+}
 
 /* GET home page. */
 router.get('/', function (req, res, next) {
@@ -25,6 +43,12 @@ const fail = { status: "fail" }
  * mount USB drive to /mnt/usb
  */
 router.get('/mount', (req, res) => {
+  if (mountInProgress) {
+    console.log('hardware-server USB mount already in progress, ignoring duplicate request')
+    res.json({ status: "busy" })
+    return
+  }
+  mountInProgress = true
   usb.mount()
     .then(() => {
       res.json(success)
@@ -32,6 +56,8 @@ router.get('/mount', (req, res) => {
       console.log('hardware-server USB mount error')
       console.error(err)
       res.json(fail)
+    }).finally(() => {
+      mountInProgress = false
     })
 })
 
@@ -50,14 +76,40 @@ router.get('/unmount', (req, res) => {
 })
 
 /**
- * copy data files from station to USB 
+ * report copy progress as file counts
+ */
+router.get('/data/progress', (req, res) => {
+  if (!copyInProgress) {
+    res.json({ status: "idle", total: 0, copied: 0 })
+    return
+  }
+  const copied = countFiles("/mnt/usb") - copyProgress.baselineFiles
+  res.json({ status: "copying", total: copyProgress.total, copied: Math.max(copied, 0) })
+})
+
+/**
+ * copy data files from station to USB
  */
 router.get('/data', (req, res, next) => {
+  if (copyInProgress) {
+    console.log('hardware-server USB data copy already in progress, ignoring duplicate request')
+    res.json({ status: "busy" })
+    return
+  }
+  copyInProgress = true
+  copyProgress.total = countFiles("/data")
+  copyProgress.baselineFiles = countFiles("/mnt/usb")
   req.setTimeout(1000 * 60 * 10) // set a 10 minute timeout for the usb transfer process to complete
+  const startTime = Date.now()
+  console.log(`hardware-server USB data copy started from /data to USB (${copyProgress.total} files)`)
   usb.copyTo("/data", /.*$/, (err) => {
+    copyInProgress = false
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
     if (err) {
+      console.log(`hardware-server USB data copy failed after ${elapsed}s`, err)
       res.json(fail)
     } else {
+      console.log(`hardware-server USB data copy completed successfully in ${elapsed}s`)
       res.json(success)
     }
   })

--- a/src/station-lcd-interface/tasks/usb-download-task.js
+++ b/src/station-lcd-interface/tasks/usb-download-task.js
@@ -1,26 +1,99 @@
 import fetch from 'node-fetch'
 import url from 'url'
+import display from '../display-driver.js'
+
+const DOWNLOAD_TIMEOUT_MS = 1000 * 60 * 10 // 10 minute timeout to match server-side
+const PROGRESS_POLL_MS = 2000
+const MAX_RETRIES = 2
+const RETRY_DELAY_MS = 5000
+const BLOCK = String.fromCharCode(0xFF) // solid filled block on HD44780
+const SPACE = " "                        // empty cell
 
 class UsbDownloadTask {
   constructor(base_url) {
     this.url = url.resolve(base_url, 'usb/data')
-    this.header = "Usb"
+    this.progressUrl = url.resolve(base_url, 'usb/data/progress')
+    this.header = 'Downloading to USB...'
+    this.retryCount = 0
   }
   loading() {
-    return [this.header, "Downloading..."]
+    this.pollProgress()
+    return [this.header, "Downloading...", SPACE.repeat(20), "0%"]
+  }
+  progressBar(copied, total) {
+    const barWidth = 20
+    if (total === 0) return SPACE.repeat(barWidth)
+    const filled = Math.min(Math.round((copied / total) * barWidth), barWidth)
+    return BLOCK.repeat(filled) + SPACE.repeat(barWidth - filled)
+  }
+  fetchProgress() {
+    fetch(this.progressUrl, { timeout: 3000 })
+      .then(res => res.json())
+      .then(progress => {
+        console.log('usb download progress', progress)
+        if (progress.status === "copying" && progress.total > 0) {
+          const pct = Math.round((progress.copied / progress.total) * 100)
+          display.write([
+            this.header,
+            `${progress.copied}/${progress.total} files`,
+            this.progressBar(progress.copied, progress.total),
+            `${pct}%`
+          ])
+        }
+      })
+      .catch((err) => {
+        console.log('usb download progress poll error', err.message)
+      })
+  }
+  pollProgress() {
+    this.fetchProgress()
+    this.progressTimer = setInterval(() => {
+      this.fetchProgress()
+    }, PROGRESS_POLL_MS)
+  }
+  stopPolling() {
+    if (this.progressTimer) {
+      clearInterval(this.progressTimer)
+      this.progressTimer = null
+    }
+  }
+  attemptDownload(resolve) {
+    fetch(this.url, { timeout: DOWNLOAD_TIMEOUT_MS })
+      .then(data => {
+        return data.json()
+      })
+      .then(res => {
+        this.stopPolling()
+        this.retryCount = 0
+        resolve([this.header, `Download:${res.status}`])
+      })
+      .catch(error => {
+        console.log(`usb download error (attempt ${this.retryCount + 1}/${MAX_RETRIES + 1})`, error.message)
+        if (this.retryCount < MAX_RETRIES) {
+          this.retryCount++
+          display.write([
+            this.header,
+            `Error - retrying...`,
+            `Attempt ${this.retryCount + 1}/${MAX_RETRIES + 1}`,
+            ""
+          ])
+          setTimeout(() => {
+            this.attemptDownload(resolve)
+          }, RETRY_DELAY_MS)
+        } else {
+          this.stopPolling()
+          this.retryCount = 0
+          if (error.type === 'request-timeout') {
+            resolve([this.header, `Download:timeout`, "", "Press select to retry"])
+          } else {
+            resolve([this.header, `Download:error`, "", "Press select to retry"])
+          }
+        }
+      })
   }
   results() {
     return new Promise((resolve, reject) => {
-      fetch(this.url)
-        .then(data => {
-          return data.json()
-        })
-        .then(res => {
-          resolve([this.header, `Download:${res.status}`])
-        })
-        .catch(error => {
-          resolve([this.header, `Download:error`])
-        })
+      this.attemptDownload(resolve)
     })
   }
 }

--- a/src/station-radio-interface/server/base-station.js
+++ b/src/station-radio-interface/server/base-station.js
@@ -320,7 +320,26 @@ class BaseStation {
     }
   }
 
-  rotateDataFiles() {
+  /**
+   * Rotate live data files into the rotated/ directory. Skipped while a USB
+   * download is in progress so the copy doesn't race against file moves —
+   * rotating mid-copy is the trigger for the ncp callback hang that leaves
+   * the hardware-server's copyInProgress flag stuck.
+   */
+  async rotateDataFiles() {
+    try {
+      const res = await fetch('http://localhost:3000/usb/data/progress', { timeout: 5000 })
+      const progress = await res.json()
+      if (progress && progress.status === 'copying') {
+        this.stationLog('rotation skipped - USB data copy in progress')
+        console.log('rotation skipped - USB data copy in progress')
+        return
+      }
+    } catch (err) {
+      // hardware-server unreachable or returned bad JSON. Fail open: a missed
+      // rotation is worse than a (probably non-existent) USB copy collision.
+      console.log('rotation: USB copy status check failed, proceeding:', err.message || err)
+    }
     this.stationLog('rotating data files')
     this.data_manager.rotate()
       .then(() => {

--- a/src/usb-storage-driver/mount-usb.js
+++ b/src/usb-storage-driver/mount-usb.js
@@ -21,10 +21,18 @@ class MountUsb {
   async unmount() {
     console.log('mount-usb unmounting USB drive', this.dir)
     if (fs.existsSync(this.dir) == false) {
-      // the path does not exist - 
+      // the path does not exist -
       return
     }
-    return Command(`umount ${this.dir}`)
+    try {
+      return await Command(`umount ${this.dir}`)
+    } catch (err) {
+      if (err.message && err.message.includes('target is busy')) {
+        console.log('mount-usb target is busy, attempting lazy unmount', this.dir)
+        return Command(`umount -l ${this.dir}`)
+      }
+      throw err
+    }
   }
 
   async clean() {

--- a/src/usb-storage-driver/usb-storage.js
+++ b/src/usb-storage-driver/usb-storage.js
@@ -50,8 +50,8 @@ class UsbStorage {
    * @param {*} callback 
    */
   copyTo(src, pattern, callback) {
-    ncp.ncp.limit = 16
-    ncp(src, this.mount_point, { 
+    ncp.ncp.limit = 2
+    ncp(src, this.mount_point, {
       filter: pattern,
       dereference: true
     }, callback)
@@ -64,7 +64,7 @@ class UsbStorage {
    * @param {*} callback 
    */
   copyFrom(src, dest, callback) {
-    ncp.ncp.limit = 16
+    ncp.ncp.limit = 2
     ncp(path.join(this.mount_point, src), dest, callback)
   }
 }


### PR DESCRIPTION
- Reduce ncp copy concurrency from 16 to 2 to prevent I/O saturation on Raspberry Pi, which was starving the Express server and causing ECONNRESET errors for other services
- Add 10-minute fetch timeout to LCD download task to match server-side
- Add LCD progress bar showing file count and percentage during transfer
- Add auto-retry (up to 3 attempts) on download failure with user feedback on the LCD screen
- Add lazy unmount fallback (umount -l) when target is busy from an in-progress copy
- Guard mount and data copy routes against duplicate concurrent requests
- Add copy progress endpoint (GET /usb/data/progress) for real-time monitoring
- Add elapsed time logging for copy start, completion, and failure