### PR TITLE
update system/scripts/list-devices.sh to support new modem and WiFi chip

### DIFF
--- a/system/scripts/list-devices.sh
+++ b/system/scripts/list-devices.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-modem=$(lsusb | grep Quectel -c)
-wifi=$(lsusb | grep Ralink -c)
+modem=$(( $(lsusb | grep Quectel -c) + $(lsusb | grep Telit -c) ))
+wifi=$(( $(lsusb | grep Ralink -c) + $(lsusb | grep Realtek -c) ))
 usb_hubs=$(lsusb | grep Microchip -c)
-radios=$(lsusb | grep Adafruit -c)
+radios=$(lsusb | grep "Adafruit Feather" -c)
 usb_devices=$(( $modem + $wifi + $usb_hubs + $radios ))
 usb_ports=$(( $(lsusb | grep Bus -c) - ($usb_devices + 1))) # +1 for linux USB controller
 


### PR DESCRIPTION
Modified system/scritps/list-devices.sh to look for Quectel OR Telit modem. Also added in a change to support the Realtek WiFi chip and have the radio count check specifically for Adafruit Feather devices rather than general Adafruit devices. This resolves an issue found in QA where the Adafruit USB key gets inaccurately reported as a built-in USB device instead of a USB port in use.