### PR TITLE
modem: Telit RNDIS fixes — enable race, autoconnect policy, dashboard…

### DIFF
--- a/src/station-interface/routes/controls/modem-signal-strength.js
+++ b/src/station-interface/routes/controls/modem-signal-strength.js
@@ -1,11 +1,48 @@
+// Proxy the modem signal strength from the hardware API for the dashboard's
+// modem icon. The icon's connected/not-connected state is driven by the real
+// connectivity probe (/modem/ppp), NOT by ModemManager's `state`.
+//
+// Why not trust mmcli `state`: on the RNDIS fleet (Telit LE910Q1) mmcli reports
+// `connected` as soon as it has a bearer, even when the modem-side NAT isn't
+// actually forwarding traffic (e.g. just after a power-cycle, before the data
+// session re-establishes). That's a false positive — the same one the ping
+// probe was built to catch. Trusting it made the dashboard claim "connected"
+// while no data could flow.
+//
+// /modem/ppp is an actual ping to 1.1.1.1 bound to the modem interface. We treat
+// reachable === true as the single source of truth for "connected", which is
+// exactly the signal the diag-B status LED uses (station-leds-v3.js). So the
+// dashboard icon and the B LED now always agree: both green/on when the modem
+// can really move data, both red/off when it can't. Raw mmcli state is kept as
+// `modem_state` for diagnostics.
 export default async (req, res) => {
-  fetch('http://localhost:3000/modem/signal-strength')
-    .then(res => res.json())
-    .then((json) => {
-      res.json(json)
+  try {
+    const [info, ppp] = await Promise.all([
+      fetch('http://localhost:3000/modem/signal-strength').then(r => r.json()).catch(() => null),
+      fetch('http://localhost:3000/modem/ppp')
+        .then(r => r.json())
+        .catch(() => ({ ppp: false })), // probe unavailable -> treat as not connected
+    ])
+
+    const reachable = ppp && ppp.ppp === true
+
+    // `info` is null when the hardware server has no fresh modem poll (modem
+    // mid-bringup, busy, or absent). Don't dereference it — the old proxy passed
+    // null straight through and render_modem shows its no-signal icon. Mirror
+    // that, but still report connected if the reachability probe says so.
+    if (!info) {
+      res.json(reachable ? { state: 'connected', reachable } : null)
+      return
+    }
+
+    res.json({
+      ...info,
+      modem_state: info.state, // raw mmcli state, preserved for diagnostics
+      reachable,
+      state: reachable ? 'connected' : 'disconnected',
     })
-    .catch((err) => {
-      console.error(err)
-      res.sendStatus(500)
-    })
+  } catch (err) {
+    console.error(err)
+    res.sendStatus(500)
+  }
 }

--- a/system/scripts/check-sim-id.sh
+++ b/system/scripts/check-sim-id.sh
@@ -8,6 +8,14 @@
 # Before=ModemManager): MM waits for that unit, the unit waited for MM. The
 # mmcli retry loop below is all we need — it waits for the modem to enumerate.
 
+# If the modem is intentionally disabled, there's no modem to configure — skip
+# both the data-path policy and APN selection. enable-modem.sh re-runs this
+# script once the modem is powered back on, so nothing is lost.
+if [ -e /etc/ctt/modem-disabled ]; then
+  echo 'check-sim-id: modem disabled — skipping data-path policy + APN selection'
+  exit 0
+fi
+
 # --- data-path policy: demote the gsm/PPP profile on Telit only ---
 # Telit LE910Q1 (1bc7:7020) uses the RNDIS data path (mdm0, modem-internal
 # NAT) — the gsm 'station-modem' profile must NOT dial PPP on it (causes a
@@ -16,19 +24,27 @@
 # (wwan0), so it MUST stay autoconnect=yes. Keyed on USB VID:PID so a Quectel
 # station is never demoted (fleet-safe). Runs here (via station-boot.service,
 # After=network.target) so NetworkManager is up for nmcli.
+#
+# Wait for a known modem to enumerate FIRST. A just-powered Telit takes ~10-15s
+# to appear on USB; deciding before it does made us wrongly take the else branch
+# and set autoconnect=yes, so NetworkManager auto-dialed PPP on the Telit and
+# broke the RNDIS path (ESM_MULTIPLE_PDN) until a reboot. If no known modem ever
+# appears, leave autoconnect UNCHANGED — never guess (the old else=yes default
+# was the trap).
+for attempt in $(seq 1 25); do
+  lsusb -d 1bc7:7020 >/dev/null 2>&1 && break   # Telit
+  lsusb -d 2c7c:0125 >/dev/null 2>&1 && break   # Quectel
+  sleep 1
+done
+
 if lsusb -d 1bc7:7020 >/dev/null 2>&1; then
     echo 'Telit LE910Q1 detected — RNDIS data path; demoting station-modem (no PPP dial)'
     sudo nmcli connection modify station-modem connection.autoconnect no
-else
-    echo 'non-Telit modem — keeping station-modem autoconnect (QMI/PPP)'
+elif lsusb -d 2c7c:0125 >/dev/null 2>&1; then
+    echo 'Quectel EC25 detected — QMI/PPP data path; keeping station-modem autoconnect'
     sudo nmcli connection modify station-modem connection.autoconnect yes
-fi
-
-# --- per-SIM APN selection (robust against the modem not being ready) ---
-# If the modem is intentionally disabled, there's no SIM to read — skip.
-if [ -e /etc/ctt/modem-disabled ]; then
-  echo 'check-sim-id: modem disabled — skipping APN selection'
-  exit 0
+else
+    echo 'no known modem visible after wait — leaving station-modem autoconnect unchanged'
 fi
 
 # Wait for the modem + SIM to enumerate before reading the ICCID. At boot the

--- a/system/scripts/enable-modem.sh
+++ b/system/scripts/enable-modem.sh
@@ -62,6 +62,19 @@ else
   raspi-gpio set 23 op dl   # press: ON_OFF# asserted LOW
   sleep 2                    # hold ~1-2s to trigger power-on
   raspi-gpio set 23 op dh   # release: ON_OFF# back to idle HIGH
+
+  # Wait for the just-powered Telit to re-enumerate on USB before falling
+  # through to check-sim-id below. check-sim-id keys its data-path policy on
+  # `lsusb -d 1bc7:7020`; if the modem isn't visible yet it takes the non-Telit
+  # branch and sets station-modem autoconnect=yes. NetworkManager then auto-dials
+  # PPP on the Telit when it appears (~10-15s later), which collides with the
+  # modem's RNDIS PDP context (ESM_MULTIPLE_PDN) and kills mdm0 connectivity
+  # until a reboot. Give it up to ~25s to appear (matches the ~15s typical).
+  echo 'waiting for Telit to re-enumerate on USB before APN/data-path policy...'
+  for i in $(seq 1 25); do
+    lsusb -d $TELIT >/dev/null 2>&1 && { echo "Telit enumerated after ~${i}s"; break; }
+    sleep 1
+  done
 fi
 
 # Re-run the per-SIM APN selection now that the modem is being enabled. This


### PR DESCRIPTION
## Problem
On Telit LE910Q1 (RNDIS) stations, disabling then re-enabling the modem via the
web button left it registered but unable to pass data until a full reboot, and
the web/LCD dashboards showed a working modem as disconnected.

## Root cause
1. Enable race — enable-modem.sh GPIO-powers the Telit, then immediately runs
   check-sim-id.sh. The modem takes ~10–15s to re-enumerate, so check-sim-id's
   `lsusb -d 1bc7:7020` check missed it, took the non-Telit branch, and set
   station-modem autoconnect=yes. When the modem appeared, NetworkManager
   auto-dialed PPP, colliding with the RNDIS PDP context (ESM_MULTIPLE_PDN) and
   killing mdm0 forwarding.
2. Dashboard — the icon greened only on mmcli state=="connected", but the healthy
   RNDIS steady state is "registered", so a working modem read as "no connection".

## Changes
- enable-modem.sh: wait for the Telit to re-enumerate before check-sim-id.
- check-sim-id.sh: wait for a known modem before the autoconnect decision; 3-way
  by VID:PID (Telit→no, Quectel→yes, neither→unchanged); skip when disabled.
- modem-signal-strength.js: drive dashboard modem state off the /modem/ppp
  reachability probe (null-safe).

## Verification (v3r0 station)
- Telit Disable→Enable keeps autoconnect=no, dials no PPP, RNDIS recovers in ~8s,
  diag-B stays on.
- Dashboard/LCD show connected only when the modem can actually reach the internet.
- Quectel (QMI/wwan0) path preserved by VID:PID branching; end-to-end Quectel data
  verification still pending a SIM.

