### PR TITLE
lcd: fix Station Stats blank-screen hang + harden hardware-API/wifi calls

### DIFF
--- a/src/hardware/pi/network/wifi.js
+++ b/src/hardware/pi/network/wifi.js
@@ -1,12 +1,22 @@
-import { execSync } from 'child_process'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const pExecFile = promisify(execFile)
 
 /**
- * 
- * @returns {Array}
+ * `nmcli device wifi list` can trigger a blocking rescan (seconds). Run it via
+ * async execFile — never execSync — so a slow/hung scan can't freeze the event
+ * loop of whatever imports this (the LCD interface's render loop, the hardware
+ * server's request handling). A hard timeout caps a stuck nmcli.
+ * @returns {Promise<Array>}
  */
-const GetNetworkList = () => {
-  const network_info = execSync('nmcli -t -f IN-USE,SSID,SIGNAL,RATE,FREQ device wifi list').toString().trim()
-  return network_info.split('\n').map((info) => {
+const GetNetworkList = async () => {
+  const { stdout } = await pExecFile(
+    'nmcli',
+    ['-t', '-f', 'IN-USE,SSID,SIGNAL,RATE,FREQ', 'device', 'wifi', 'list'],
+    { encoding: 'utf8', timeout: 8000 }
+  )
+  return stdout.trim().split('\n').map((info) => {
     const [in_use, ssid, signal, rate, freq] = info.split(':')
     return {
       connected: (in_use === '*') ? true : false,
@@ -20,17 +30,17 @@ const GetNetworkList = () => {
 
 export default Object.freeze({
   /**
-   * 
-   * @returns {Object} return 
+   *
+   * @returns {Promise<Object>} return
    */
-  GetCurrentNetwork: () => {
-    return GetNetworkList().find(network => network.connected)
+  GetCurrentNetwork: async () => {
+    return (await GetNetworkList()).find(network => network.connected)
   },
   /**
-   * 
-   * @returns {Array} array of networks visible to twifi
+   *
+   * @returns {Promise<Array>} array of networks visible to twifi
    */
-  GetNetworks: () => {
+  GetNetworks: async () => {
     return GetNetworkList()
   }
 })

--- a/src/station-hardware-server/routes/internet.js
+++ b/src/station-hardware-server/routes/internet.js
@@ -74,8 +74,8 @@ router.get('/pending-upload', async (req, res, next) => {
   }
 })
 
-router.get('/wifi-networks', (req, res, next) => {
-  const wifi = Wifi.GetCurrentNetwork()
+router.get('/wifi-networks', async (req, res, next) => {
+  const wifi = await Wifi.GetCurrentNetwork()
   if (wifi) {
     res.json(wifi)
   } else {

--- a/src/station-lcd-interface/index.js
+++ b/src/station-lcd-interface/index.js
@@ -11,7 +11,7 @@ import { watchRadioInterface } from './radio-watch.js'
 
 // App Config
 
-const host = 'http://localhost:3000'
+const host = 'http://127.0.0.1:3000'
 
 /*
     Build the menu: Each item MUST be given:

--- a/src/station-lcd-interface/menu-manager.js
+++ b/src/station-lcd-interface/menu-manager.js
@@ -51,8 +51,6 @@ class MenuManager {
     */
     if (this.focus.childCount() == 0) {
       if (this.focus.view != null) {
-        console.log('this view', this.view_())
-
         this.view_()
         return
       }
@@ -84,8 +82,14 @@ class MenuManager {
     }
     this.update_()
   }
-  view_() {
-    display.write(this.focus.view.loading())
+  view_(refresh = false) {
+    // On first entry show the view's loading placeholder (Station Stats returns
+    // [] to clear the menu underneath). On an auto-refresh, do NOT blank — keep
+    // the current frame until results() re-renders, so a slow or failed refresh
+    // can never leave the screen blank.
+    if (!refresh) {
+      display.write(this.focus.view.loading())
+    }
 
     this.focus.view.results().then((rows) => {
       if (rows != null) {
@@ -93,7 +97,10 @@ class MenuManager {
       }
       this.autoRefresh_(true)
     }).catch((err) => {
-      display.write(["Error", err, "", ""])
+      display.write(["Error", String(err), "", ""])
+      // Re-arm on failure too, so a bad cycle can never permanently stop the
+      // refresh loop (which previously stranded the view on a blank screen).
+      this.autoRefresh_(true)
     })
   }
   update_() {
@@ -117,7 +124,7 @@ class MenuManager {
       if (typeof this.focus.view.autoRefresh !== 'undefined') {
         if (this.focus.view.autoRefresh > 0) {
           this.refresh_ = setTimeout(() => {
-            this.view_()
+            this.view_(true)
           }, this.focus.view.autoRefresh)
         }
       }

--- a/src/station-lcd-interface/menu-translator.js
+++ b/src/station-lcd-interface/menu-translator.js
@@ -51,7 +51,7 @@ class MenuTranslator {
 
   async createItems(language, lang_string) {
 
-    const host = 'http://localhost:3000'
+    const host = 'http://127.0.0.1:3000'
 
     this.items = new MenuItem(language, null, [
       new MenuItem('Station Stats', new StationStats(host), []),

--- a/src/station-lcd-interface/station-stats.js
+++ b/src/station-lcd-interface/station-stats.js
@@ -40,7 +40,7 @@ class StationStats {
       // Wifi is still read in-process (no equivalent /wifi endpoint yet).
       // Modem now flows through hardware-server's /modem cache so the LCD
       // doesn't fork its own mmcli subprocesses on each refresh.
-      const network = Network.Wifi.GetCurrentNetwork()
+      const network = await Network.Wifi.GetCurrentNetwork()
 
       const wifi_signal = network && network.connected == true ? network.signal : undefined
       // Show modem signal whenever the modem is alive and reporting a value.

--- a/src/station-lcd-interface/station-stats.js
+++ b/src/station-lcd-interface/station-stats.js
@@ -23,10 +23,15 @@ class StationStats {
   }
   async results() {
     try {
+      // Bound every fetch with a timeout. Without one, a hung hardware-server
+      // request (e.g. /modem while mmcli is momentarily busy) never settles, so
+      // results() never resolves — the menu-manager refresh chain then never
+      // re-arms and the screen is left blank permanently (loading() clears it
+      // first). A 3s abort turns a hang into a rejection we handle and recover from.
       const [voltages, temperature, modem] = await Promise.all([
-        fetch(this.volt_url).then(r => r.json()),
-        fetch(this.temp_url).then(r => r.json()),
-        fetch(this.modem_url).then(r => r.json()).catch(() => null),
+        fetch(this.volt_url, { signal: AbortSignal.timeout(3000) }).then(r => r.json()),
+        fetch(this.temp_url, { signal: AbortSignal.timeout(3000) }).then(r => r.json()),
+        fetch(this.modem_url, { signal: AbortSignal.timeout(3000) }).then(r => r.json()).catch(() => null),
       ])
 
       await this.getBattVoltage(voltages)


### PR DESCRIPTION
## Problem
The front-panel Station Stats LCD screen could get stuck on a permanently blank
display. In the field this reproduced by degrading the modem (pulling the
antenna): the screen went blank and never recovered until a service restart.

## Root cause (two layers)
1. Refresh blanks then can hang. On each 10s refresh, menu-manager.view_() first
   writes the view's loading() placeholder — [] for Station Stats, i.e. a full
   clear — then re-renders from results(). results() fetched /sensor/* and /modem
   via node-fetch with no timeout; a hung request never settled, so the .then
   that re-arms the refresh never ran. Screen left blank, refresh loop dead.
2. node-fetch wedged on the IPv6 loopback. The LCD used http://localhost:3000;
   localhost resolves to ::1 first, but the hardware server listens only on
   127.0.0.1. Under load, repeated aborted fetches down the dead ::1 path
   poisoned node-fetch — every fetch aborted for 15+ min while a fresh process
   was fine. Only a restart cleared it.

## Changes
66b6c0a — refresh-hang fix
- station-stats.js: AbortSignal.timeout(3000) on every fetch so a hang becomes a
  handled rejection and the cycle recovers.
- menu-manager.js: don't blank on refresh (loading() only on first entry);
  re-arm autoRefresh_ in .catch too; drop a debug console.log that
  double-invoked view_().

ca49aec — connection + wifi hardening
- LCD talks to 127.0.0.1:3000, avoiding the ::1 path.
- wifi.js GetCurrentNetwork/GetNetworks use async execFile (was execSync) with an
  8s timeout so a slow nmcli rescan can't freeze the event loop; callers await.

## Verification (v3r3 station, 2.0.0)
- Antenna out→in now updates Station Stats live instead of wedging.
- :3000 connections cycle 0→3→0 per refresh (no leak), zero ::1 conns, zero aborts.
- All services healthy; /wifi-networks (now async) returns 200.
