### PR TITLE
Modem authorize refactor

### DIFF
--- a/system/scripts/check-sim-id.sh
+++ b/system/scripts/check-sim-id.sh
@@ -1,57 +1,26 @@
 #!/usr/bin/bash
+# check-sim-id.sh — per-SIM APN selection. ONE job: read the SIM ICCID via mmcli
+# and set the station-modem NetworkManager profile's APN for that carrier.
+#
+# The modem data-path autoconnect policy (Telit=no / Quectel=yes) is NOT here — it
+# moved to modem-datapath.sh. Splitting APN from policy (and moving both off the
+# enable path) is what un-tangled this from enable-modem.sh.
+#
+# Runs after ModemManager is up: from station-boot.service (After=ModemManager)
+# and from enable-modem.sh on a runtime enable. It does NOT start MM — MM ships
+# enabled and systemd starts it at boot; the mmcli retry loop below waits for the
+# modem + SIM to enumerate.
 
-# NOTE: this script does NOT start ModemManager. MM ships enabled in the image
-# and systemd starts it at boot; disable-modem.sh never stops it (it only
-# USB-deauthorizes / powers the modem, MM keeps running and auto-detects the
-# modem on re-enable via udev). A blocking `systemctl start ModemManager` here
-# used to deadlock when this ran from modem-boot-state.service (ordered
-# Before=ModemManager): MM waits for that unit, the unit waited for MM. The
-# mmcli retry loop below is all we need — it waits for the modem to enumerate.
-
-# If the modem is intentionally disabled, there's no modem to configure — skip
-# both the data-path policy and APN selection. enable-modem.sh re-runs this
-# script once the modem is powered back on, so nothing is lost.
+# A disabled (deauthorized) modem can't report an ICCID — skip. enable-modem.sh
+# re-runs this once the modem is authorized again, so nothing is lost.
 if [ -e /etc/ctt/modem-disabled ]; then
-  echo 'check-sim-id: modem disabled — skipping data-path policy + APN selection'
+  echo 'check-sim-id: modem disabled — skipping APN selection'
   exit 0
 fi
 
-# --- data-path policy: demote the gsm/PPP profile on Telit only ---
-# Telit LE910Q1 (1bc7:7020) uses the RNDIS data path (mdm0, modem-internal
-# NAT) — the gsm 'station-modem' profile must NOT dial PPP on it (causes a
-# competing default route + duplicate ICMP and an ESM_MULTIPLE_PDN retry
-# loop). Quectel EC25 (2c7c:0125) uses that same profile for its QMI bearer
-# (wwan0), so it MUST stay autoconnect=yes. Keyed on USB VID:PID so a Quectel
-# station is never demoted (fleet-safe). Runs here (via station-boot.service,
-# After=network.target) so NetworkManager is up for nmcli.
-#
-# Wait for a known modem to enumerate FIRST. A just-powered Telit takes ~10-15s
-# to appear on USB; deciding before it does made us wrongly take the else branch
-# and set autoconnect=yes, so NetworkManager auto-dialed PPP on the Telit and
-# broke the RNDIS path (ESM_MULTIPLE_PDN) until a reboot. If no known modem ever
-# appears, leave autoconnect UNCHANGED — never guess (the old else=yes default
-# was the trap).
-for attempt in $(seq 1 25); do
-  lsusb -d 1bc7:7020 >/dev/null 2>&1 && break   # Telit
-  lsusb -d 2c7c:0125 >/dev/null 2>&1 && break   # Quectel
-  sleep 1
-done
-
-if lsusb -d 1bc7:7020 >/dev/null 2>&1; then
-    echo 'Telit LE910Q1 detected — RNDIS data path; demoting station-modem (no PPP dial)'
-    sudo nmcli connection modify station-modem connection.autoconnect no
-elif lsusb -d 2c7c:0125 >/dev/null 2>&1; then
-    echo 'Quectel EC25 detected — QMI/PPP data path; keeping station-modem autoconnect'
-    sudo nmcli connection modify station-modem connection.autoconnect yes
-else
-    echo 'no known modem visible after wait — leaving station-modem autoconnect unchanged'
-fi
-
-# Wait for the modem + SIM to enumerate before reading the ICCID. At boot the
-# modem may still be coming up (a Telit needs a GPIO pulse; a modem enabled
-# after boot needs time), and reading an EMPTY ICCID is how this script used
-# to silently fall through to the wrong 'super' default. Retry until a valid
-# ICCID appears; if none ever does, leave the APN UNCHANGED (never guess).
+# Wait for the modem + SIM to enumerate before reading the ICCID. Reading an EMPTY
+# ICCID is how this used to silently fall through to the wrong default; retry until
+# a valid ICCID appears, and if none ever does, leave the APN UNCHANGED (never guess).
 iccid=""
 for attempt in $(seq 1 15); do
   modem_index="$(/usr/bin/mmcli -L 2>/dev/null | grep -oE 'Modem/[0-9]+' | grep -oE '[0-9]+' | head -1)"

--- a/system/scripts/check-sim-id.sh
+++ b/system/scripts/check-sim-id.sh
@@ -6,13 +6,14 @@
 # moved to modem-datapath.sh. Splitting APN from policy (and moving both off the
 # enable path) is what un-tangled this from enable-modem.sh.
 #
-# Runs after ModemManager is up: from station-boot.service (After=ModemManager)
-# and from enable-modem.sh on a runtime enable. It does NOT start MM — MM ships
-# enabled and systemd starts it at boot; the mmcli retry loop below waits for the
-# modem + SIM to enumerate.
+# Runs at boot from station-boot.service (After=ModemManager) — the single place
+# APN is set. (A runtime enable does not run this inline; enable-modem.sh reboots,
+# so this runs on the next boot.) It does NOT start MM — MM ships enabled and
+# systemd starts it at boot; the mmcli retry loop below waits for the modem + SIM
+# to enumerate.
 
-# A disabled (deauthorized) modem can't report an ICCID — skip. enable-modem.sh
-# re-runs this once the modem is authorized again, so nothing is lost.
+# A disabled (deauthorized) modem can't report an ICCID — skip. The next enable
+# reboots the station, so this runs once the modem is back and authorized.
 if [ -e /etc/ctt/modem-disabled ]; then
   echo 'check-sim-id: modem disabled — skipping APN selection'
   exit 0

--- a/system/scripts/disable-modem.sh
+++ b/system/scripts/disable-modem.sh
@@ -1,67 +1,25 @@
 #!/bin/bash
-# Disable the cellular modem. The mechanism depends on which modem is
-# installed; we detect by USB VID:PID.
+# Disable the cellular modem: deauthorize its USB device. Uniform for every modem
+# (Telit LE910Q1, Quectel EC25); no GPIO / ON_OFF#.
 #
-#   Telit LE910Q1 (1bc7:7020):  pulse GPIO 23 (ON_OFF#) LOW 6s → release HIGH
-#     GPIO 23 was rewired on the R3b adapter to drive ON_OFF# directly;
-#     >3s LOW triggers Telit's hardware shutdown (we use 6s for margin),
-#     then release HIGH so the line returns to its idle state. Full power-off:
-#     modem disappears from USB, LTE radio stops, ~150-200mA saved.
-#     Spec ref: hardware/TELIT_LE910Q1_INTEGRATION_REPORT.md
+# Deauthorize (modem-power.sh off) has the kernel unbind all drivers and
+# ModemManager drop the modem, but the module stays powered and VISIBLE in lsusb
+# (so QAQC still sees it) and re-enable is a clean rebind — no re-enumeration wait.
 #
-#   Quectel EC25 (2c7c:0125):  deauthorize the parent USB device
-#     Quectel has no software power control on V3 (it's "auto-on with VCC"
-#     per the integration report — MODEM_U_DISABLE# on GPIO 23 doesn't
-#     actually trigger USB disconnect on the deployed boards). Instead we
-#     use kernel USB authorization: writing 0 to /sys/bus/usb/devices/.../
-#     authorized triggers a clean USB-level disconnect — kernel unbinds
-#     all drivers, ModemManager clears its cached state, and the modem
-#     closes its QMI sessions cleanly so re-enable doesn't suffer from
-#     QMI transaction-ID staleness the way module-blacklist did.
-#     Modem stays powered (RF radio still on, ~50mA idle).
+# Deliberate tradeoff: unlike the old Telit GPIO power-off, deauthorize leaves the
+# module powered (RF idle, ~50 mA) — it does NOT save the ~150-200 mA a full
+# power-down did. We chose one consistent, idempotent, QAQC-visible control over
+# the Telit-only power saving; a station that isn't using cellular has its modem
+# physically removed.
+#
+# Writes the /etc/ctt/modem-disabled intent marker so modem-boot-state.sh
+# re-applies the deauthorize on the next boot (authorized resets to 1 when the
+# modem re-enumerates).
+set -u
 
-TELIT='1bc7:7020'
-QUECTEL='2c7c:0125'
-
-# Persistent intent marker. Presence means "operator wants modem OFF" and
-# is consulted by modem-boot-state.service to restore state across hard
-# reboots. Created here so a power cycle re-applies the disabled state
-# (relevant for Quectel — it auto-boots ON without this hint).
+SCRIPT_DIR='/lib/ctt/sensor-station-software/system/scripts'
 MARKER='/etc/ctt/modem-disabled'
+
 mkdir -p "$(dirname "$MARKER")"
 touch "$MARKER"
-
-# Walk /sys/bus/usb/devices to find the parent device matching a VID:PID.
-# Echoes the sysfs path or returns 1 if not found.
-find_usb_parent() {
-  local vid="$1" pid="$2"
-  for p in /sys/bus/usb/devices/*; do
-    [ -f "$p/idVendor" ] || continue
-    if [ "$(cat "$p/idVendor" 2>/dev/null)" = "$vid" ] && \
-       [ "$(cat "$p/idProduct" 2>/dev/null)" = "$pid" ]; then
-      echo "$p"
-      return 0
-    fi
-  done
-  return 1
-}
-
-if lsusb -d $TELIT >/dev/null 2>&1; then
-  echo 'disabling Telit LE910Q1 (pulse GPIO 23 LOW 6s, release HIGH)'
-  raspi-gpio set 23 op dh   # ensure HIGH idle for a clean falling edge
-  sleep 0.1
-  raspi-gpio set 23 op dl   # press: ON_OFF# asserted LOW
-  sleep 6                    # hold >5s to trigger shutdown
-  raspi-gpio set 23 op dh   # release: ON_OFF# back to idle HIGH
-elif lsusb -d $QUECTEL >/dev/null 2>&1; then
-  vid="${QUECTEL%:*}"; pid="${QUECTEL#*:}"
-  path=$(find_usb_parent "$vid" "$pid")
-  if [ -z "$path" ]; then
-    echo "ERROR: Quectel detected by lsusb but not found in sysfs"
-    exit 1
-  fi
-  echo "disabling Quectel EC25 (deauthorize USB device at $path)"
-  echo 0 > "$path/authorized"
-else
-  echo 'no known modem detected (looked for Telit 1bc7:7020, Quectel 2c7c:0125); nothing to disable'
-fi
+bash "$SCRIPT_DIR/modem-power.sh" off

--- a/system/scripts/enable-modem.sh
+++ b/system/scripts/enable-modem.sh
@@ -1,24 +1,47 @@
 #!/bin/bash
-# Enable the cellular modem: authorize its USB device so drivers rebind and
-# ModemManager re-detects it. Uniform for every modem (Telit LE910Q1, Quectel
-# EC25) — both self-enumerate on VBAT, so there is NO GPIO / ON_OFF# handling.
+# Enable the cellular modem, then reboot so the boot sequence brings it up and
+# configures it. enable-modem only sets INTENT and ensures the modem will be on
+# the bus; the configuration is the boot sequence's job and is NOT duplicated
+# here:
+#   modem-boot-state (Before=MM): authorize per the (now-cleared) marker
+#   station-boot (After=MM):      data-path autoconnect policy + per-SIM APN
 #
-# Steps: clear the /etc/ctt/modem-disabled intent marker, authorize the modem
-# (modem-power.sh on), then run per-SIM APN selection now that the modem can be
-# read. The data-path autoconnect policy is intentionally NOT set here — it is a
-# static, per-modem-type decision owned by boot (modem-datapath.sh via
-# station-boot). Keeping it out of the enable path is what removed the PPP-dial
-# collision: enabling can never mis-set autoconnect.
+# Steps:
+#   1. Clear the /etc/ctt/modem-disabled marker (intent = ON).
+#   2. If no modem is on the bus, a Telit may be in ON_OFF# shutdown (a soft
+#      reboot won't clear that — VBAT stays up), so pulse ON_OFF# once to power it
+#      on. It finishes enumerating during the reboot; modem-boot-state's wait
+#      catches it. A deauthorized modem is already on the bus, so no pulse.
+#   3. Reboot — scheduled a couple seconds out so the web/LCD caller gets its
+#      response before the system goes down.
+#
+# Only ever invoked by the operator (web/LCD), never by a boot unit, so this
+# cannot reboot-loop. The pin comes from the board layer (CTT_MODEM_ONOFF_GPIO in
+# /run/ctt/board.env; fallback 23); the pulse keeps the field-proven raspi-gpio
+# drive-and-hold.
 set -u
 
-SCRIPT_DIR='/lib/ctt/sensor-station-software/system/scripts'
 MARKER='/etc/ctt/modem-disabled'
 
-rm -f "$MARKER"
-bash "$SCRIPT_DIR/modem-power.sh" on
+[ -r /run/ctt/board.env ] && . /run/ctt/board.env
+ONOFF_GPIO="${CTT_MODEM_ONOFF_GPIO:-23}"
 
-# APN needs the modem authorized (the ICCID is read over mmcli), so it can only
-# run once enabled. At boot a disabled modem skipped APN selection, so run it now.
-# check-sim-id waits for the modem + SIM to enumerate.
-CHECK_SIM="$SCRIPT_DIR/check-sim-id.sh"
-[ -f "$CHECK_SIM" ] && bash "$CHECK_SIM"
+modem_on_bus() {
+  lsusb -d 1bc7:7020 >/dev/null 2>&1 || lsusb -d 2c7c:0125 >/dev/null 2>&1
+}
+
+rm -f "$MARKER"
+
+# Recovery only: nothing on the bus means a Telit may be in ON_OFF# shutdown.
+if ! modem_on_bus; then
+  echo "enable-modem: no modem on USB — pulsing ON_OFF# (GPIO $ONOFF_GPIO) to power on a shut-down Telit"
+  raspi-gpio set "$ONOFF_GPIO" op dh   # idle HIGH for a clean falling edge
+  sleep 0.1
+  raspi-gpio set "$ONOFF_GPIO" op dl   # assert LOW
+  sleep 2                               # hold ~2s to trigger power-on
+  raspi-gpio set "$ONOFF_GPIO" op dh   # release to idle HIGH
+fi
+
+sync
+echo "enable-modem: rebooting to bring up + configure the modem (authorize, data-path, APN) at boot"
+systemd-run --on-active=2 /bin/systemctl reboot >/dev/null 2>&1 || systemctl reboot

--- a/system/scripts/enable-modem.sh
+++ b/system/scripts/enable-modem.sh
@@ -1,96 +1,24 @@
 #!/bin/bash
-# Enable the cellular modem. The mechanism depends on which modem is
-# installed and on its current state:
+# Enable the cellular modem: authorize its USB device so drivers rebind and
+# ModemManager re-detects it. Uniform for every modem (Telit LE910Q1, Quectel
+# EC25) — both self-enumerate on VBAT, so there is NO GPIO / ON_OFF# handling.
 #
-#   Quectel EC25 (2c7c:0125) visible in lsusb:
-#     A deauthorized Quectel still shows up in lsusb (descriptors live in
-#     sysfs regardless of driver binding). It's either healthy or sitting
-#     deauthorized; re-authorize to bind drivers and let ModemManager
-#     re-detect via fresh udev events. If already authorized, this is a
-#     no-op write.
-#
-#   Telit LE910Q1 (1bc7:7020) visible in lsusb:
-#     Already powered on (Telit only enumerates after boot, since disable
-#     cuts VBAT entirely). No-op.
-#
-#   No modem visible:
-#     Assume Telit that was powered off (Quectel always shows in lsusb
-#     even when deauthorized — its absence implies the variant is Telit
-#     and it was last powered off). Pulse GPIO 23 (ON_OFF#) LOW ~2s then
-#     release HIGH. Modem takes ~15s to enumerate on USB; MM picks it up.
-#     Spec ref: hardware/TELIT_LE910Q1_INTEGRATION_REPORT.md
+# Steps: clear the /etc/ctt/modem-disabled intent marker, authorize the modem
+# (modem-power.sh on), then run per-SIM APN selection now that the modem can be
+# read. The data-path autoconnect policy is intentionally NOT set here — it is a
+# static, per-modem-type decision owned by boot (modem-datapath.sh via
+# station-boot). Keeping it out of the enable path is what removed the PPP-dial
+# collision: enabling can never mis-set autoconnect.
+set -u
 
-TELIT='1bc7:7020'
-QUECTEL='2c7c:0125'
-
-# Persistent intent marker. Presence means "operator wants modem OFF" and
-# is consulted by modem-boot-state.service to restore state across hard
-# reboots. Removed here so enable-modem.sh always clears intent.
+SCRIPT_DIR='/lib/ctt/sensor-station-software/system/scripts'
 MARKER='/etc/ctt/modem-disabled'
+
 rm -f "$MARKER"
+bash "$SCRIPT_DIR/modem-power.sh" on
 
-# Walk /sys/bus/usb/devices to find the parent device matching a VID:PID.
-# Echoes the sysfs path or returns 1 if not found.
-find_usb_parent() {
-  local vid="$1" pid="$2"
-  for p in /sys/bus/usb/devices/*; do
-    [ -f "$p/idVendor" ] || continue
-    if [ "$(cat "$p/idVendor" 2>/dev/null)" = "$vid" ] && \
-       [ "$(cat "$p/idProduct" 2>/dev/null)" = "$pid" ]; then
-      echo "$p"
-      return 0
-    fi
-  done
-  return 1
-}
-
-if lsusb -d $QUECTEL >/dev/null 2>&1; then
-  vid="${QUECTEL%:*}"; pid="${QUECTEL#*:}"
-  path=$(find_usb_parent "$vid" "$pid")
-  if [ -z "$path" ]; then
-    echo "ERROR: Quectel detected by lsusb but not found in sysfs"
-    exit 1
-  fi
-  echo "enabling Quectel EC25 (authorize USB device at $path)"
-  echo 1 > "$path/authorized"
-elif lsusb -d $TELIT >/dev/null 2>&1; then
-  echo 'Telit LE910Q1 already powered on; no action needed'
-else
-  echo 'no modem currently visible; assuming Telit LE910Q1 powered off, pulsing GPIO 23 LOW 2s'
-  raspi-gpio set 23 op dh   # ensure HIGH idle for a clean falling edge
-  sleep 0.1
-  raspi-gpio set 23 op dl   # press: ON_OFF# asserted LOW
-  sleep 2                    # hold ~1-2s to trigger power-on
-  raspi-gpio set 23 op dh   # release: ON_OFF# back to idle HIGH
-
-  # Wait for the just-powered Telit to re-enumerate on USB before falling
-  # through to check-sim-id below. check-sim-id keys its data-path policy on
-  # `lsusb -d 1bc7:7020`; if the modem isn't visible yet it takes the non-Telit
-  # branch and sets station-modem autoconnect=yes. NetworkManager then auto-dials
-  # PPP on the Telit when it appears (~10-15s later), which collides with the
-  # modem's RNDIS PDP context (ESM_MULTIPLE_PDN) and kills mdm0 connectivity
-  # until a reboot. Give it up to ~25s to appear (matches the ~15s typical).
-  echo 'waiting for Telit to re-enumerate on USB before APN/data-path policy...'
-  for i in $(seq 1 25); do
-    lsusb -d $TELIT >/dev/null 2>&1 && { echo "Telit enumerated after ~${i}s"; break; }
-    sleep 1
-  done
-fi
-
-# Re-run the per-SIM APN selection now that the modem is being enabled. This
-# covers the boot-disabled-then-enabled-later case: at boot station-boot's
-# check-sim-id ran with no modem (skipped), so the APN was never set for this
-# SIM. check-sim-id waits for the modem+SIM to enumerate (handles the GPIO/USB
-# bring-up delay) and only sets the APN once it reads a valid ICCID.
-# SKIP_CHECK_SIM is set by modem-boot-state.sh at boot: that unit is ordered
-# Before=ModemManager.service, and check-sim-id.sh does a blocking
-# `systemctl start ModemManager`, so running it from there deadlocks (MM waits
-# for modem-boot-state to finish; modem-boot-state waits for MM to start). At
-# boot, station-boot.service runs check-sim-id for APN selection instead. For a
-# manual / web "enable after boot", SKIP_CHECK_SIM is unset and we run it here.
-CHECK_SIM=/usr/lib/ctt/sensor-station-software/system/scripts/check-sim-id.sh
-if [ -n "$SKIP_CHECK_SIM" ]; then
-  echo 'enable-modem: SKIP_CHECK_SIM set (boot-state restore) — leaving APN to station-boot'
-elif [ -f "$CHECK_SIM" ]; then
-  bash "$CHECK_SIM"
-fi
+# APN needs the modem authorized (the ICCID is read over mmcli), so it can only
+# run once enabled. At boot a disabled modem skipped APN selection, so run it now.
+# check-sim-id waits for the modem + SIM to enumerate.
+CHECK_SIM="$SCRIPT_DIR/check-sim-id.sh"
+[ -f "$CHECK_SIM" ] && bash "$CHECK_SIM"

--- a/system/scripts/modem-boot-state.sh
+++ b/system/scripts/modem-boot-state.sh
@@ -1,32 +1,35 @@
 #!/bin/bash
-# Restore the cellular modem to the operator's last-set state at boot.
+# Reconcile the cellular modem's on/off state to the operator's intent at boot.
 #
-# Semantics:
-#   /etc/ctt/modem-disabled present  → operator wants modem OFF → disable-modem.sh
-#   /etc/ctt/modem-disabled absent   → default = modem ON       → enable-modem.sh
+#   /etc/ctt/modem-disabled present → deauthorize (modem OFF)
+#   absent                          → authorize   (modem ON, default)
 #
-# This pairs with enable-modem.sh / disable-modem.sh, which maintain the
-# marker on every state change. It exists because a hard reboot (power
-# switch) cuts VBAT to the Telit LE910Q1, and Telit boots OFF until it
-# receives an ON_OFF# pulse — see system/systemd/modem-boot-state.service
-# and hardware/TELIT_LE910Q1_INTEGRATION_REPORT.md for context.
+# `authorized` is runtime state that resets to 1 when the modem re-enumerates on a
+# reboot (both Telit and Quectel self-enumerate on VBAT), so we re-apply the
+# intent here. Ordered Before=ModemManager so MM's first scan sees the intended
+# authorization. This step is pure USB sysfs (modem-power.sh) — no nmcli/mmcli —
+# so it is safe before NetworkManager/ModemManager are up. The data-path
+# autoconnect policy and per-SIM APN are owned by station-boot (After=MM):
+# modem-datapath.sh + check-sim-id.sh.
+set -u
 
-MARKER='/etc/ctt/modem-disabled'
 SCRIPT_DIR='/lib/ctt/sensor-station-software/system/scripts'
+MARKER='/etc/ctt/modem-disabled'
+
+# Wait for the self-enumerating modem to appear on USB before applying the intent,
+# so a disabled station reliably deauthorizes it before ModemManager (ordered
+# after us) scans. Breaks as soon as a known modem appears; bounded so a station
+# with no modem doesn't stall boot.
+for i in $(seq 1 25); do
+  lsusb -d 1bc7:7020 >/dev/null 2>&1 && break   # Telit
+  lsusb -d 2c7c:0125 >/dev/null 2>&1 && break   # Quectel
+  sleep 1
+done
 
 if [ -e "$MARKER" ]; then
-  echo "modem-boot-state: marker present at $MARKER — restoring disabled state"
-  exec "$SCRIPT_DIR/disable-modem.sh"
+  echo "modem-boot-state: marker present — modem OFF (deauthorize)"
+  exec bash "$SCRIPT_DIR/modem-power.sh" off
 else
-  echo "modem-boot-state: no marker — restoring enabled state (default)"
-  # SKIP_CHECK_SIM: do NOT let enable-modem.sh run check-sim-id.sh here.
-  # This unit is ordered Before=ModemManager.service, and check-sim-id does a
-  # blocking `systemctl start ModemManager` — running it from inside a
-  # Before=MM unit deadlocks (MM waits for us to finish; we wait for MM to
-  # start). APN selection at boot is station-boot.service's job
-  # (After=network.target, no Before=MM), which runs check-sim-id safely. The
-  # tail-call only matters for a manual / web "enable after boot", where
-  # SKIP_CHECK_SIM is unset and check-sim-id runs.
-  export SKIP_CHECK_SIM=1
-  exec "$SCRIPT_DIR/enable-modem.sh"
+  echo "modem-boot-state: no marker — modem ON (authorize, default)"
+  exec bash "$SCRIPT_DIR/modem-power.sh" on
 fi

--- a/system/scripts/modem-datapath.sh
+++ b/system/scripts/modem-datapath.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# modem-datapath.sh — set the station-modem NetworkManager profile's autoconnect
+# by modem TYPE (USB VID:PID). This is a static, per-modem-type decision: it is
+# set once at boot (station-boot.service) and is deliberately NOT on the operator
+# enable/disable path — re-deriving it there, racing USB enumeration, was the
+# cause of the Telit PPP-dial collision.
+#
+#   Telit LE910Q1 (1bc7:7020): RNDIS data path (mdm0, modem-internal NAT). The gsm
+#     'station-modem' PPP profile must NOT autodial — a PPP context collides with
+#     the RNDIS PDP context (ESM_MULTIPLE_PDN) and kills mdm0.  => autoconnect no
+#   Quectel EC25 (2c7c:0125): QMI/PPP bearer on that same profile (wwan0).
+#                                                                 => autoconnect yes
+#
+# VID:PID is readable whether the modem is authorized or deauthorized (the device
+# stays enumerated either way), so this is correct regardless of on/off state. If
+# no known modem is visible, leave autoconnect UNCHANGED — never guess. Runs from
+# station-boot.service (After=NetworkManager) so nmcli is available.
+set -u
+
+TELIT='1bc7:7020'
+QUECTEL='2c7c:0125'
+
+if lsusb -d "$TELIT" >/dev/null 2>&1; then
+  echo 'modem-datapath: Telit LE910Q1 — station-modem autoconnect=no (RNDIS, no PPP dial)'
+  sudo nmcli connection modify station-modem connection.autoconnect no
+elif lsusb -d "$QUECTEL" >/dev/null 2>&1; then
+  echo 'modem-datapath: Quectel EC25 — station-modem autoconnect=yes (QMI/PPP)'
+  sudo nmcli connection modify station-modem connection.autoconnect yes
+else
+  echo 'modem-datapath: no known modem visible — leaving station-modem autoconnect unchanged'
+fi

--- a/system/scripts/modem-power.sh
+++ b/system/scripts/modem-power.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# modem-power.sh {on|off} — set the cellular modem's USB authorization.
+#
+# One uniform mechanism for every supported modem (Telit LE910Q1 1bc7:7020,
+# Quectel EC25 2c7c:0125): both self-enumerate on the USB bus whenever VBAT is
+# present, so we never touch GPIO / ON_OFF#.
+#
+#   off = deauthorize (echo 0 > .../authorized): the kernel unbinds all drivers
+#         and ModemManager drops the modem, but the device stays powered and
+#         VISIBLE in lsusb (QAQC-friendly), and re-enable is a clean driver
+#         rebind with no re-enumeration wait.
+#   on  = authorize   (echo 1 > .../authorized).
+#
+# Idempotent: the sysfs write is a no-op if the device is already in that state,
+# so this is a level (declarative) operation, not an edge/toggle. `authorized` is
+# runtime state (resets to 1 on re-enumeration / reboot); the persistent operator
+# intent lives in /etc/ctt/modem-disabled, which modem-boot-state.sh reconciles.
+set -u
+
+TELIT='1bc7:7020'
+QUECTEL='2c7c:0125'
+
+usage() { echo "usage: modem-power.sh {on|off}" >&2; exit 2; }
+[ "$#" -eq 1 ] || usage
+case "$1" in
+  on)  val=1 ;;
+  off) val=0 ;;
+  *)   usage ;;
+esac
+
+# Walk /sys/bus/usb/devices for the parent device matching a VID:PID.
+find_usb_parent() {
+  local vid="$1" pid="$2" p
+  for p in /sys/bus/usb/devices/*; do
+    [ -f "$p/idVendor" ] || continue
+    if [ "$(cat "$p/idVendor" 2>/dev/null)" = "$vid" ] && \
+       [ "$(cat "$p/idProduct" 2>/dev/null)" = "$pid" ]; then
+      echo "$p"; return 0
+    fi
+  done
+  return 1
+}
+
+for vidpid in "$TELIT" "$QUECTEL"; do
+  path="$(find_usb_parent "${vidpid%:*}" "${vidpid#*:}")" || continue
+  echo "modem-power: $1 $vidpid ($path)"
+  if echo "$val" > "$path/authorized"; then
+    exit 0
+  fi
+  echo "modem-power: ERROR writing $path/authorized" >&2
+  exit 1
+done
+
+echo "modem-power: no known modem on USB (Telit $TELIT / Quectel $QUECTEL); nothing to do"
+exit 0

--- a/system/systemd/modem-boot-state.service
+++ b/system/systemd/modem-boot-state.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Restore cellular modem on/off state at boot
-# Run after /etc is mounted (we read /etc/ctt/modem-disabled) and after
-# udev has populated /sys/bus/usb so lsusb works inside enable-/disable-
-# modem.sh. Run BEFORE ModemManager so its first scan sees the intended
-# state without us having to deauthorize after MM has already cached it.
+# Run after /etc is mounted (we read /etc/ctt/modem-disabled) and after udev has
+# populated /sys/bus/usb so lsusb + the authorize sysfs node exist. Run BEFORE
+# ModemManager so its first scan sees the intended authorization state without us
+# having to deauthorize after MM has already cached it.
 After=local-fs.target systemd-udev-settle.service
 Before=ModemManager.service
 DefaultDependencies=yes
@@ -11,14 +11,11 @@ DefaultDependencies=yes
 [Service]
 Type=oneshot
 RemainAfterExit=true
-# Wait long enough for an auto-enumerating modem to appear in lsusb so
-# enable-/disable-modem.sh pick the correct branch. The Quectel EC25 is
-# "auto-on with VCC" and typically enumerates within 3-5s of power; the
-# 5s settle covers slow USB initialization without delaying boot
-# noticeably. (Telit cold boots take ~15s to enumerate AFTER GPIO 23 is
-# pulsed, so we don't try to wait for Telit pre-pulse — enable-modem.sh
-# handles the "no modem visible" case correctly.)
-ExecStartPre=/bin/sleep 5
+# modem-boot-state.sh reconciles the /etc/ctt/modem-disabled marker to the USB
+# authorization (authorize = on, deauthorize = off) via modem-power.sh. Both the
+# Telit LE910Q1 and Quectel EC25 self-enumerate on VBAT, so there is no GPIO/pulse
+# step and no fixed settle here — the script waits (bounded) for the modem to
+# appear on USB before applying the intent.
 ExecStart=/lib/ctt/sensor-station-software/system/scripts/modem-boot-state.sh
 
 [Install]

--- a/system/systemd/station-boot.service
+++ b/system/systemd/station-boot.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=Station modem/SIM APN selection
-# Runs check-sim-id.sh (modem data-path policy + per-SIM APN). Hardware identity
-# and the RTC overlay that save-station-id.sh used to do are now owned by
-# ctt-board-detect / ctt-device-config.
-# After ModemManager so check-sim-id runs once MM is active and can enumerate the
+Description=Station modem data-path policy + per-SIM APN selection
+# Runs modem-datapath.sh (autoconnect by modem type) then check-sim-id.sh (per-SIM
+# APN) — the two modem-config steps that need NetworkManager/ModemManager up.
+# Hardware identity and the RTC overlay that save-station-id.sh used to do are now
+# owned by ctt-board-detect / ctt-device-config; the modem on/off authorization is
+# owned by modem-boot-state (Before=MM).
+# After ModemManager so both steps run once MM is active and can enumerate the
 # modem. Ordering only (no Requires/Wants): MM is already enabled, and if it ever
 # fails to start, this unit still runs.
 # Chain: modem-boot-state (Before=MM) -> ModemManager -> station-boot.
@@ -11,6 +13,7 @@ After=network.target ModemManager.service
 
 [Service]
 Type=oneshot
+ExecStart=/lib/ctt/sensor-station-software/system/scripts/modem-datapath.sh
 ExecStart=/lib/ctt/sensor-station-software/system/scripts/check-sim-id.sh
 RemainAfterExit=true
 


### PR DESCRIPTION
Decouple check-sim-id.sh from modem enable/disabling.   Use USB authorize for consistent 'deactivation/activation'.