### PR TITLE
blu: broadcast unlink_port on detach; guard null STATS/VERSION payloads

### DIFF
--- a/src/station-interface/public/javascripts/interface.js
+++ b/src/station-interface/public/javascripts/interface.js
@@ -901,10 +901,14 @@ const handle_add_port = function (data) {
 }
 
 const handle_blu_unlink = function (data) {
-  let unlink_port = data.port
-  document.querySelector(`#blu-receiver-${unlink_port}`).style.display = 'none'
-  let unlink_index = blu_ports.findIndex(port => port === unlink_port)
-  blu_ports.splice(unlink_index, 1)
+  // Coerce to string: add_port stores ports in blu_ports as strings, so the
+  // lookup below must compare as strings (a raw-number compare never matched,
+  // and splice(-1) then dropped the wrong entry).
+  let unlink_port = data.port.toString()
+  let el = document.querySelector(`#blu-receiver-${unlink_port}`)
+  if (el) { el.style.display = 'none' }
+  let unlink_index = blu_ports.findIndex(port => port.toString() === unlink_port)
+  if (unlink_index !== -1) { blu_ports.splice(unlink_index, 1) }
 }
 
 const handle_dongle_unlink = function (data) {

--- a/src/station-radio-interface/server/blu-base-station.js
+++ b/src/station-radio-interface/server/blu-base-station.js
@@ -186,6 +186,10 @@ class BluStation {
 
       switch (task) {
         case BluReceiverTask.VERSION:
+          // An errored/timed-out VERSION poll arrives with data:null; reading
+          // data.version below would throw — and this case has no try/catch, so
+          // it would be an uncaught rejection. Skip when there's no payload.
+          if (!data) { break }
 
           this.blu_fw = {
             msg_type: 'blu-firmware',
@@ -254,6 +258,11 @@ class BluStation {
         case BluReceiverTask.CONFIG:
           break
         case BluReceiverTask.STATS:
+          // A STATS poll that errored/timed out arrives with data:null (the
+          // receiver sets data:null on error). Guard before reading det_dropped
+          // so a faulty receiver doesn't throw (caught below, but only after
+          // logging a spurious "blu station stats error" on every poll).
+          if (!job.data) { break }
           try {
 
             let port_key = blu_receiver.port.toString()
@@ -361,6 +370,11 @@ class BluStation {
     const receiver = this.blu_receivers.find(r => r.port === channel)
     if (!receiver) return
     this.blu_receivers = this.blu_receivers.filter(r => r.port !== channel)
+    // Tell the web UI to hide this port's table. Mirrors the add_port broadcast
+    // in startBluRadios and keys off the same value (the receiver channel), so
+    // when the receiver is re-attached on the same port add_port re-fires and
+    // the table reappears.
+    this.broadcast(JSON.stringify({ msg_type: 'unlink_port', port: channel }))
     try {
       await this.destroy_receiver(receiver)
     } catch (e) {


### PR DESCRIPTION
Two related BluSeries fixes on the **Node side only** — no native-binary change, so this can ship via normal OTA independently of #32 (the DTR native fix).

## 1. Web receiver-table lifecycle (unplug → table disappears, replug → reappears)

When a BluSeries receiver's driver socket vanished (unplug, or driver stop), `base-station`'s reconcile already called `BluStation.removeReceiver()` — but nothing told the web UI, so the port's table stayed on screen forever.

`removeReceiver()` now broadcasts `{ msg_type: 'unlink_port', port: channel }`, mirroring the `add_port` broadcast in `startBluRadios` and keyed on the same channel value. The web already had `handle_blu_unlink` wired to that message — it hides `#blu-receiver-<port>`. `add_port` re-fires when the receiver re-attaches, so the table reappears on the same port.

Also hardened `handle_blu_unlink`: `blu_ports` stores port **strings** (via `add_port`'s `.toString()`), so the raw number-vs-string compare never matched and `splice(-1)` dropped the wrong entry; the `querySelector` is now null-guarded too.

## 2. Null-payload guards on errored polls

An errored/timed-out receiver poll arrives with `data: null`.
- **STATS** read `job.data.det_dropped` → threw (caught by its `try/catch`, but only after logging a spurious "blu station stats error" on *every* poll while a receiver is faulty).
- **VERSION** read `data.version` with **no** `try/catch` → uncaught rejection.

Both now skip cleanly when there's no payload.

## Verification (real hardware)

WS client on `:8001` while stopping/starting a receiver's driver (stop unlinks its socket — exactly what the reconcile watcher keys on):

```
[ws] unlink_port port=2
[ws] add_port port=2 blu_channel=1
[ws] add_port port=2 blu_channel=2
[ws] add_port port=2 blu_channel=3
[ws] add_port port=2 blu_channel=4
```

Exactly one `unlink_port` despite both detach paths (`stopBluSocket` + `receiver.on('close')`) firing — the `if (!receiver) return` guard holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)