### PR TITLE
fix(ota): stop web-triggered update-station from killing itself on ra…

### DIFF
--- a/src/station-radio-interface/server/base-station.js
+++ b/src/station-radio-interface/server/base-station.js
@@ -239,8 +239,40 @@ class BaseStation {
    * @param {*} cmd - run a given bash command and pipe output to web socket
    */
   runCommand(cmd) {
-    const command_process = spawn(cmd)
     this.stationLog('running command', cmd)
+    // update-station restarts station-radio-interface — this very service. A plain
+    // child shares our systemd cgroup, so that restart would SIGKILL it mid-update
+    // (frozen LCD "Updating" splash, skipped sensorgnome + image-OTA steps). Launch
+    // it as a transient systemd unit instead: it runs in its own cgroup under
+    // system.slice and survives our restart. Its output goes to the journal, so we
+    // stream progress by following that unit's journal rather than a pipe (the pipe
+    // would die with us on the restart anyway).
+    if (cmd === 'update-station') {
+      const unit = 'ctt-ota-update'
+      spawn('systemd-run', [
+        '--collect', '--unit', unit,
+        `--setenv=PATH=${process.env.PATH}`,
+        `--setenv=HOME=${process.env.HOME || '/root'}`,
+        '/usr/local/sbin/update-station',
+      ]).on('error', (err) => {
+        console.error('update-station launch error')
+        console.error(err)
+        this.stationLog('update-station launch error', err.toString())
+      })
+      this.streamProcess(spawn('journalctl', ['-f', '-o', 'cat', '--since', 'now', '-u', unit]), cmd)
+      return
+    }
+    this.streamProcess(spawn(cmd), cmd)
+  }
+
+  /**
+   * Pipe a child process's stdout/stderr to all web-socket clients as `log`
+   * messages, and log its lifecycle.
+   * @param {*} command_process - a spawned child process
+   * @param {*} label - human label for logs (defaults to the process spawnfile)
+   */
+  streamProcess(command_process, label) {
+    label = label || command_process.spawnfile
     command_process.stdout.on('data', (data) => {
       let msg = {
         data: data.toString(),
@@ -258,7 +290,7 @@ class BaseStation {
       this.broadcast(JSON.stringify(msg))
     })
     command_process.on('close', (code) => {
-      this.stationLog('finished running', cmd, code)
+      this.stationLog('finished running', label, code)
     })
     command_process.on('error', (err) => {
       console.error('command error')

--- a/system/scripts/update-station.sh
+++ b/system/scripts/update-station.sh
@@ -133,11 +133,15 @@ echo 'CTT Sensor Station Software Update Complete'
 echo '*******************************************'
 
 sudo systemctl restart station-hardware-server
-# station-lcd-interface is intentionally NOT restarted here — it stays stopped so
-# the "Updating" splash remains on the panel through the rest of the update; the
-# EXIT trap restarts it (restoring the menu) once everything below is done.
-sudo systemctl restart station-radio-interface
 sudo systemctl restart station-web-interface
+# station-lcd-interface is intentionally NOT restarted here — it stays stopped so
+# the "Updating" splash remains on the panel through the rest of the update; it is
+# restored near the end (or by the EXIT trap on any earlier failure path).
+# station-radio-interface is intentionally NOT restarted here either: when the
+# update is launched from the web dashboard this script runs as a CHILD of that
+# service, so restarting it now tears down our cgroup and SIGKILLs us mid-update
+# (frozen "Updating" splash, skipped sensorgnome + image-OTA). It is restarted
+# LAST, once all real work is done — see the end of this script.
 
 echo '********************'
 echo 'Updating Sensorgnome'
@@ -175,3 +179,12 @@ echo
 echo '***********************'
 echo 'STATION UPDATE COMPLETE'
 echo '***********************'
+
+# LAST action, deliberately after everything above. When the update is launched
+# from the web dashboard, station-radio-interface is the service hosting this
+# script, so restarting it tears down the service cgroup and SIGKILLs us. Doing it
+# here means all real work (code pull, hooks, sensorgnome, image OTA, LCD restore)
+# is already done, so losing the process now is harmless; systemd still carries out
+# the enqueued restart after the requesting process dies. (Run from SSH/cron we are
+# not a child of the service, so this is just an ordinary restart.)
+sudo systemctl restart station-radio-interface


### PR DESCRIPTION
…dio-interface restart

The web dashboard's "Station Update" button spawns update-station as a plain child of station-radio-interface (base-station.js runCommand -> spawn). Midway, update-station.sh runs `systemctl restart station-radio-interface`, which tears down that service's cgroup and SIGKILLs the updater before it can restore the LCD, update sensorgnome, or run the data upload. SIGKILL also bypasses the EXIT trap, so the front panel is left frozen on the "Updating..." splash. SSH/cron runs are unaffected (not children of the service), which is why this slipped through testing.

Two complementary fixes:

- base-station.js: launch update-station as a transient systemd unit (`systemd-run --collect --unit ctt-ota-update`) so it runs in its own cgroup under system.slice and survives the radio-interface restart. Its output goes to the journal, streamed to the dashboard by following that unit's journal (the old stdout pipe died with us on the restart anyway).

- update-station.sh: make the station-radio-interface restart the LAST action, after sensorgnome update, data upload, and the LCD menu restore. Defense in depth so a non-decoupled invocation (SSH/cron, or a future regression) still completes all work before the self-restart.