### PR TITLE
fix(tag-db): import fs so SG tag database uploads persist

### DIFF
--- a/src/station-interface/routes/sensorgnome/upload-sg-tag-file.js
+++ b/src/station-interface/routes/sensorgnome/upload-sg-tag-file.js
@@ -1,3 +1,5 @@
+import fs from 'fs'
+
 import RunCommand from '../../../command.js'
 
 const BASE_SG_TAG_DB_NAME = 'SG_tag_database'


### PR DESCRIPTION
## Problem

Uploading a SensorGnome tag database through the web interface silently destroyed the existing database and stored nothing. The SensorGnome interface then failed with:

```
Error reading file: {"code":1,...,"cmd":"/usr/bin/sqlite3 /data/sg_files/SG_tag_database.sqlite 'select ... from tags ...'"}
```

i.e. `Error: no such table: tags`, because `/data/sg_files/SG_tag_database.sqlite` was left empty (0 bytes).

## Root cause

`src/station-interface/routes/sensorgnome/upload-sg-tag-file.js` calls `fs.writeFileSync(uri, req.body)` but only imported `RunCommand` — `fs` was never imported. The handler runs in order:

1. `rm /data/sg_files/SG_tag_database*` — deletes the current tag DB (succeeds)
2. `fs.writeFileSync(...)` — throws `ReferenceError: fs is not defined`

So every upload wiped the old database and wrote nothing. Confirmed on-station in the `station-web-interface` logs:

```
tag database upload
about to delete sg tag db files
executing command rm /data/sg_files/SG_tag_database*
writing tag database file
something went wrong handling new SG tag database file
ReferenceError: fs is not defined
    at .../upload-sg-tag-file.js:14:7
```

## Fix

Add the missing `import fs from 'fs'`.

## Follow-up (not in this PR)

The handler still `rm`s the existing DB *before* writing the new one, so an aborted/invalid upload can still destroy a working database. A safer pattern would write to a temp file and rename into place only on success. Left out here to keep this a focused, minimal fix for the reported bug.

## Related

Same fix for the `lts_24-06.iso` branch: #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)