### PR TITLE
fix(tag-db): rm -f so first-time tag DB upload works

### DIFF
--- a/src/station-interface/routes/sensorgnome/upload-sg-tag-file.js
+++ b/src/station-interface/routes/sensorgnome/upload-sg-tag-file.js
@@ -9,7 +9,10 @@ export default (req, res, next) => {
   const ext = req.get('file-extension')
   const filename = `${BASE_SG_TAG_DB_NAME}.${ext}`
   console.log('about to delete sg tag db files')
-  RunCommand(`rm /data/sg_files/${BASE_SG_TAG_DB_NAME}*`)
+  // Use rm -f: on a station with no existing tag DB the glob matches nothing,
+  // and a plain rm exits non-zero, rejecting the promise before the write ever
+  // runs. -f treats "nothing to remove" as success.
+  RunCommand(`rm -f /data/sg_files/${BASE_SG_TAG_DB_NAME}*`)
     .then(() => {
       let uri = `/data/sg_files/${filename}`
       console.log('writing tag database file')


### PR DESCRIPTION
## Problem

Uploading a SensorGnome tag database on a station that has **no existing tag DB** fails with:

```
Error: Command failed: rm /data/sg_files/SG_tag_database*
rm: cannot remove '/data/sg_files/SG_tag_database*': No such file or directory
```

## Root cause

`upload-sg-tag-file.js` runs `rm /data/sg_files/SG_tag_database*` before writing the new file. When no tag DB exists yet, the glob matches nothing, plain `rm` exits non-zero, `RunCommand` rejects, and the handler aborts in `.catch` before `fs.writeFileSync` ever runs. Confirmed on a v3r0 station (lts_24_06 line) at upload time.

## Fix

Use `rm -f`, which treats "nothing to remove" as success. Verified end-to-end on-device: `POST /upload-sg-tag-file` → `{"res":true}` / 200 and the file is written.

## Context

Follow-up to the `fs` import fix (PR #40, already merged here). Sibling change for the `lts_24-06.iso` line is in PR #39. The fs-import PR for this branch (#40) was already merged and its branch deleted, so this is a fresh PR rather than an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)