### PR TITLE
fix(ci): actually bake native binaries into the image (cross-arch checksum-trust + fail-loud)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,18 +1,26 @@
-# Build a distributable sensor-station SD-card image in CI — incrementally.
+# Build a distributable sensor-station eMMC image (Raspberry Pi Compute Module,
+# flashed via rpiboot over USB — there is no SD card) in CI, incrementally.
 #
 # Mirrors the manual process (loop-mount the last image, update the software in
 # the mount, shrink, upload to S3), but pguyot/arm-runner-action does the
 # loop-mount + qemu-arm binfmt so update-station.sh runs INSIDE the image's ARM
-# rootfs exactly as it does on a field station.
+# rootfs.
 #
-# What runs in the image (via update-station.sh):
-#   - git pull sensor-station-software + sensorgnome  (public HTTPS, no creds)
-#   - post-merge.sh hooks -> install-native fetches the pinned armhf binaries,
-#     install-systemd / install-udev deploy units + rules
-#   - npm install if package.json changed (runs under qemu — slow but correct)
-# Its `systemctl restart` calls are harmless no-ops here (no systemd in the
-# chroot) and don't abort the run (update-station.sh has no `set -e`); the image
-# starts services fresh on first boot regardless.
+# It runs in CTT_BUILD_MODE (see update-station.sh), which differs from a field
+# station in exactly three ways the build requires:
+#   - native binaries install by checksum+pin (install-native's run-it-to-check
+#     `--version` smoke test can't work under emulation), so the pinned binaries
+#     actually get baked in;
+#   - a failed deploy hook is FATAL and fails the build (no more green-but-broken
+#     images), enforced by `|| exit 1` on the update-station call below;
+#   - station-runtime steps are skipped (LCD splash, and the image-OTA
+#     checkin/upload session — a build must not impersonate a station).
+#
+# What still runs: git pull sensor-station-software + sensorgnome (public HTTPS),
+# npm install if package.json changed, and the post-merge deploy hooks
+# (install-native / install-systemd / install-udev). `systemctl restart` calls are
+# harmless no-ops here (no systemd in the chroot); the image starts services fresh
+# on first boot.
 #
 # The base image is assumed ALREADY sanitized (prepare-image.sh was run when the
 # base was generated) and ALREADY checked out on the release branch — this job
@@ -91,7 +99,12 @@ jobs:
             # ownership"). Point HOME at the image's /root and pre-trust all repos.
             export HOME=/root
             git config --global --add safe.directory '*'
-            bash /usr/lib/ctt/sensor-station-software/system/scripts/update-station.sh
+            # CTT_BUILD_MODE: install natives by checksum+pin (can't exec armhf under
+            # emulation), run deploy hooks without sudo so the flag survives + FATAL on
+            # failure, and skip station-runtime steps (LCD, image-OTA checkin/upload).
+            # `|| exit 1` fails the image build loudly instead of publishing a
+            # green-but-broken image. See update-station.sh.
+            CTT_BUILD_MODE=1 bash /usr/lib/ctt/sensor-station-software/system/scripts/update-station.sh || exit 1
             # Reclaim rootfs space so PiShrink can reach the real minimum. OTA/npm/apt leave
             # caches, package lists, and logs behind that inflate the fs (and thus the burn
             # size). Safe: apt lists regenerate on `apt update`; logs/caches are recreated.
@@ -132,7 +145,7 @@ jobs:
           # imager writes it in full -> ~3x slower to burn, esp. over rpiboot's USB 2.0 link).
           # PiShrink shrinks the ext4 root to its minimum and truncates the .img. -s skips
           # PiShrink's OWN autoexpand -- ctt-firstboot-resize.service grows the rootfs to fill the
-          # card on first boot (fail-safe), matching the historical Ansible+PiShrink image sizes.
+          # eMMC on first boot (fail-safe), matching the historical Ansible+PiShrink image sizes.
           curl -fsSL https://raw.githubusercontent.com/Drewsif/PiShrink/master/pishrink.sh -o pishrink.sh
           chmod +x pishrink.sh
           sudo ./pishrink.sh -s -v "${{ steps.build.outputs.image }}"

--- a/system/scripts/hooks/post-merge.d/install-native.sh
+++ b/system/scripts/hooks/post-merge.d/install-native.sh
@@ -99,6 +99,7 @@ for pinfile in "$PINS_DIR"/*.version; do
 
   # Optional checksum verification (preferred). Absent sidecar → fall back to
   # the --version smoke test below.
+  checksum_verified=0
   sum_tmp="$(mktemp)"
   if curl -fsSL --retry 2 -o "$sum_tmp" "$url.sha256" 2>/dev/null; then
     expected="$(awk '{print $1}' "$sum_tmp")"
@@ -109,21 +110,35 @@ for pinfile in "$PINS_DIR"/*.version; do
       FAILURES=$((FAILURES + 1))
       continue
     fi
+    checksum_verified=1
     log_info "$tool: checksum ok"
   else
     log_warn "$tool: no .sha256 published; relying on --version smoke test"
   fi
   rm -f "$sum_tmp"
 
-  # Smoke test: the fetched binary must run on this host and report the pin.
-  # Catches wrong-arch / truncated downloads that still returned HTTP 200.
+  # Verify before installing. Preferred: RUN it and confirm `--version` prints the
+  # pin (catches wrong-arch / truncated downloads that still returned HTTP 200).
+  #
+  # Exception — cross-arch image build: the build provisions inside an *emulated*
+  # ARM rootfs where our fetched armhf binaries do not execute (they run fine on
+  # real hardware), so the exec smoke test always yields ''. When the caller sets
+  # CTT_NATIVE_TRUST_CHECKSUM=1 AND we verified the sha256 above, trust the
+  # checksum+pin (integrity from the sha256, version from the pinned release tag)
+  # and skip the exec test. On a station the flag is unset, so the exec smoke test
+  # still runs — a valid wrong-arch/truncation guard there. Never trust without a
+  # verified checksum.
   chmod 0755 "$tmp"
-  got="$("$tmp" --version 2>/dev/null)"
-  if [ "$got" != "$pin" ]; then
-    log_error "$tool: fetched binary reports '$got', expected '$pin'; not installing"
-    rm -f "$tmp"
-    FAILURES=$((FAILURES + 1))
-    continue
+  if [ "${CTT_NATIVE_TRUST_CHECKSUM:-0}" = "1" ] && [ "$checksum_verified" = "1" ]; then
+    log_info "$tool: trusting sha256+pin (build mode; --version smoke test skipped)"
+  else
+    got="$("$tmp" --version 2>/dev/null)"
+    if [ "$got" != "$pin" ]; then
+      log_error "$tool: fetched binary reports '$got', expected '$pin'; not installing"
+      rm -f "$tmp"
+      FAILURES=$((FAILURES + 1))
+      continue
+    fi
   fi
 
   install -o root -g root -m 0755 "$tmp" "$dst"

--- a/system/scripts/update-station.sh
+++ b/system/scripts/update-station.sh
@@ -17,6 +17,21 @@ export GIT_CONFIG_COUNT=1
 export GIT_CONFIG_KEY_0='safe.directory'
 export GIT_CONFIG_VALUE_0='*'
 
+# CTT_BUILD_MODE: set by the image-build CI (build-image.yml), which runs this
+# script INSIDE the base image under qemu to layer updates onto it. In that mode:
+#   - fetch native binaries by checksum+pin (CTT_NATIVE_TRUST_CHECKSUM=1): the armhf
+#     binaries can't be executed under the build's emulation, so install-native's
+#     run-it-to-check-version smoke test cannot be used there;
+#   - run the deploy hooks WITHOUT sudo (already root; keeps the environment — incl.
+#     the flag above, which `sudo` would strip) and treat a hook failure as FATAL,
+#     so a broken bake cannot ship as a green build;
+#   - skip station-runtime-only steps (the LCD "Updating" splash, the image-OTA
+#     checkin/upload session).
+# When unset (a real station via SSH/cron/dashboard) every behavior below is unchanged.
+if [ -n "${CTT_BUILD_MODE:-}" ]; then
+  export CTT_NATIVE_TRUST_CHECKSUM=1
+fi
+
 home='/usr/lib/ctt'
 user_perm='ctt:ctt'
 sudo mkdir -p $home
@@ -36,7 +51,7 @@ dir="$home/sensor-station-software"
 # Ctrl-C), so the panel never gets stuck on "Updating". lcd-message.sh ships in
 # this repo, so the splash is a harmless no-op on the first update that adds it.
 lcd_msg="$dir/system/scripts/lcd-message.sh"
-if [ -x "$lcd_msg" ]; then
+if [ -z "${CTT_BUILD_MODE:-}" ] && [ -x "$lcd_msg" ]; then
   trap 'sudo systemctl restart station-lcd-interface >/dev/null 2>&1 || true' EXIT
   sudo systemctl stop station-lcd-interface >/dev/null 2>&1 || true
   sudo bash "$lcd_msg" " CTT Sensor Station" "" "   Updating..." "" || true
@@ -57,7 +72,11 @@ if [ -d $dir ]; then
   # not the one being pulled; new pre-merge hooks activate on the NEXT
   # update after their introducing release lands. See pre-merge.sh.
   if [ -x "$dir/system/scripts/hooks/pre-merge.sh" ]; then
-    sudo bash "$dir/system/scripts/hooks/pre-merge.sh"
+    if [ -n "${CTT_BUILD_MODE:-}" ]; then
+      bash "$dir/system/scripts/hooks/pre-merge.sh" || { echo "update-station: pre-merge hooks failed (build mode)"; exit 1; }
+    else
+      sudo bash "$dir/system/scripts/hooks/pre-merge.sh"
+    fi
   fi
   # The pull must be authoritative: this script has no `set -e`, so a silent pull
   # failure (transient network / DNS / GitHub blip) would otherwise let the rest
@@ -114,7 +133,13 @@ fi
 # file into that dir — this line stays unchanged. Runs for both the
 # update path (git pull) and the fresh-clone path so a freshly-cloned
 # repo also deploys its configs into /etc/.
-sudo bash $dir/system/scripts/hooks/post-merge.sh
+if [ -n "${CTT_BUILD_MODE:-}" ]; then
+  # Build: run as root (no sudo → keeps CTT_NATIVE_TRUST_CHECKSUM) and FAIL hard so a
+  # broken native / systemd / udev bake cannot be published as a green image.
+  bash $dir/system/scripts/hooks/post-merge.sh || { echo "update-station: post-merge hooks failed (build mode)"; exit 1; }
+else
+  sudo bash $dir/system/scripts/hooks/post-merge.sh
+fi
 
 sudo sh -c "date -u +'%Y-%m-%d %H:%M:%S' > /etc/ctt/station-software"
 
@@ -164,10 +189,14 @@ check_run package.json "npm install"
 sync
 sudo systemctl restart sensorgnome
 
-echo
-echo 'Checking for OTA updates'
-bash-update-station
-echo
+# Station-only: check the image-OTA endpoint + open a data-upload session. Skipped in
+# a build — the image must not impersonate a station checking in / uploading.
+if [ -z "${CTT_BUILD_MODE:-}" ]; then
+  echo
+  echo 'Checking for OTA updates'
+  bash-update-station
+  echo
+fi
 
 # Update finished — restore the front-panel menu (picks up any new code) and
 # clear the trap now that we've restored explicitly. The trap remains the safety


### PR DESCRIPTION
## Actually bake native binaries into the eMMC image

### The bug
Since the native-OTA hook was introduced (2026-06-19), **no image build has ever
installed a native binary.** `install-native` verifies a fetched binary by **running it**
(`<tool> --version`), but the image build runs inside an **emulated-ARM** rootfs where the
fetched **armhf** binaries don't execute — so the check returned `''` and refused to
install, for **every tool, every build**. The failure was then **swallowed**:
`update-station` is fail-open by design (a hook failure must never brick a remote station),
and `build-image` trusted its exit code — so the job went **green** on an image with
stale/no native binaries.

**Consequence:** a freshly-flashed station ran whatever the *base* image baked
(e.g. `ctt-modem-provision` **0.1.0**) until its first on-station OTA. 

### Fix
- **`install-native.sh`** — when `CTT_NATIVE_TRUST_CHECKSUM=1` **and** the sha256 verified,
  install on **checksum + pin** and skip the run-it `--version` smoke test. On a station
  (flag unset) the exec test still runs — a valid wrong-arch/truncation guard there.
- **`update-station.sh`** — a guarded **`CTT_BUILD_MODE`**: sets the checksum flag, runs the
  deploy hooks **without `sudo`** (so the flag survives — `sudo` was stripping it) and
  **FATAL** on failure, and skips station-runtime steps (LCD splash, the image-OTA
  checkin/upload). **Station path is byte-for-byte unchanged when the flag is unset.**
- **`build-image.yml`** — invoke `CTT_BUILD_MODE=1 … update-station.sh || exit 1` so a
  failed bake **fails the build** instead of shipping green; fix the terminology
  (**eMMC image / Compute Module, flashed via rpiboot — not an SD card**).

### Why it matters
With this, cutting an image bakes the pinned native binaries, so the modem provisioner
(and every native tool) reaches a **fresh flash**, not just OTA'd stations. Pairs with
#43 (ctt-modem-provision 0.3.1): once both land + the pin bumps, a fresh flash ships the
one-boot Telit + cause-55 Quectel provisioner.

### Notes / follow-ups
- The `--version` smoke test's qemu-exec failure mode wasn't root-caused to the exact
  signal; not needed — the fix is to not gate the bake on executing the binary.
- Separate: bump `system/native/ctt-modem-provision.version` → 0.3.1 after #43 is tagged
  and `native-release` publishes the armhf asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
