### PR TITLE
fix(image-bake): skip runtime NM/udev reload in CTT_BUILD_MODE

### DIFF
--- a/system/scripts/hooks/_lib.sh
+++ b/system/scripts/hooks/_lib.sh
@@ -130,8 +130,19 @@ deploy_dir() {
   [ "${REMOVED_COUNT:-0}" -gt 0 ] && changed=1
 
   if [ "$changed" = "1" ] && [ -n "$reload_cmd" ]; then
-    log_info "reloading via: $reload_cmd"
-    $reload_cmd
+    # In an image bake (CTT_BUILD_MODE) there is no running daemon to signal:
+    # the hooks run inside the base image under qemu, where NetworkManager and
+    # udevd are not up, so a runtime reload (nmcli/udevadm) either hard-fails
+    # (nmcli: "Could not connect") or is meaningless. The freshly-installed
+    # files are read when the daemon first starts on the flashed station's boot,
+    # so the reload is purely a runtime-activation step — skip it, don't fail the
+    # build on it. On a real station (flag unset) the reload runs as before.
+    if [ -n "${CTT_BUILD_MODE:-}" ]; then
+      log_info "installed (build mode: skipping runtime reload '$reload_cmd' — applies on first boot)"
+    else
+      log_info "reloading via: $reload_cmd"
+      $reload_cmd
+    fi
   elif [ "$changed" = "0" ]; then
     log_info "no changes"
   fi


### PR DESCRIPTION
## What

The fail-loud image bake (#44) surfaced a **pre-existing, previously-swallowed** failure: `install-network.sh` runs `nmcli connection reload` (via `deploy_dir`), but inside the qemu build chroot NetworkManager's D-Bus isn't running, so nmcli exits non-zero (`Could not connect: No such file or directory`) and — now that build mode is FATAL — fails the whole image build.

This was **always** broken in the bake; it was only swallowed until #44 made build mode fail-loud. The 0.3.1 native bake itself succeeded (`ctt-modem-provision: installed 0.3.1`) — this is simply the next hook the fail-loud change revealed.

## Fix

A reload is a pure runtime-activation signal to an already-running daemon. In a bake there's no daemon to signal; the freshly-installed files are read when NetworkManager/udevd first start on the flashed station's boot. So `deploy_dir` now **skips `$reload_cmd` when `CTT_BUILD_MODE` is set** and logs that it applies on first boot, instead of running (and failing on) it.

Centralized in `deploy_dir` so it also covers the latent `udevadm control --reload` case in `install-udev.sh` (same failure mode on any future udev-rule change). `install-systemd.sh`'s own `systemctl` calls are already chroot-safe (systemd no-ops with "Running in chroot").

On a real station (flag unset) the reload runs **exactly as before**.

## Evidence

Failing run `30049893975`:
```
[install-native] INFO  ctt-modem-provision: installed 0.3.1   ← bake bug fixed ✓
Error: failed to reload connections: Could not connect: No such file or directory.
[post-merge] ERROR install-network.sh exited 1
[post-merge] ERROR 1 of 4 hook(s) failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)