### PR TITLE
fix(lcd): scrolling out of a view moves focus, not just the drawn rows

### DIFF
--- a/src/station-lcd-interface/README.md
+++ b/src/station-lcd-interface/README.md
@@ -87,10 +87,15 @@ a button:
 
 | Button | Operation | Behavior |
 |--------|-----------|----------|
-| Up | `up()` | Move selection up one row |
-| Down | `down()` | Move selection down one row |
+| Up | `up()` | Move selection up one row (leaves the current view first, keeping the selection) |
+| Down | `down()` | Move selection down one row (leaves the current view first, keeping the selection) |
 | Select | `select()` | Enter a submenu, or run/refresh the selected item's view |
-| Back | `back()` | Return to the parent menu |
+| Back | `back()` | Return to the parent menu (selection resets to the first row) |
+
+While a view is on screen, Up/Down exit it back to the menu it was launched from
+— the scroller still holds that menu's rows, so the highlight stays where the
+operator left it. Back also exits, but re-initializes the scroller. Select inside
+a view re-runs `results()` (a manual refresh) rather than navigating.
 
 `MenuScroller` keeps a 4-row window over the current submenu's item names so
 lists longer than the screen scroll smoothly; the selected row is marked with a

--- a/src/station-lcd-interface/menu-manager.js
+++ b/src/station-lcd-interface/menu-manager.js
@@ -31,13 +31,32 @@ class MenuManager {
   }
   up() {
     this.autoRefresh_(false)
+    this.exitView_()
     this.scroller.up()
     this.update_()
   }
   down() {
     this.autoRefresh_(false)
+    this.exitView_()
     this.scroller.down()
     this.update_()
+  }
+  // Entering a view (Station Stats, any leaf task) does NOT re-init the
+  // scroller — the scroller keeps the *parent* menu's rows while `focus` moves
+  // to the view. So up()/down() used to redraw the parent list while focus was
+  // still the view: the screen looked like it had returned to the menu, but the
+  // next select() saw `focus.childCount() == 0 && focus.view != null` and just
+  // re-ran the view — so highlighting "System" and pressing select bounced the
+  // operator back into Station Stats. Scrolling out of a view now pops focus for
+  // real, matching the list that is already on screen.
+  //
+  // Deliberately no scroller.init() here: the scroller already holds the parent's
+  // rows and the operator's selection, and re-initializing would snap the
+  // highlight back to the first row mid-scroll.
+  exitView_() {
+    if (this.focus.view != null && this.stack.length > 0) {
+      this.focus = this.stack.pop()
+    }
   }
   select() {
     this.autoRefresh_(false)
@@ -83,20 +102,32 @@ class MenuManager {
     this.update_()
   }
   view_(refresh = false) {
+    // Pin the view we were asked to render. results() is async and some tasks
+    // are slow (Ping, and Station Stats allows up to 3s per fetch), so the
+    // operator can navigate away before it settles. Without this check the
+    // resolved rows get painted over whatever menu they navigated to.
+    const view = this.focus.view
+
     // On first entry show the view's loading placeholder (Station Stats returns
     // [] to clear the menu underneath). On an auto-refresh, do NOT blank — keep
     // the current frame until results() re-renders, so a slow or failed refresh
     // can never leave the screen blank.
     if (!refresh) {
-      display.write(this.focus.view.loading())
+      display.write(view.loading())
     }
 
-    this.focus.view.results().then((rows) => {
+    view.results().then((rows) => {
+      if (this.focus.view !== view) {
+        return
+      }
       if (rows != null) {
         display.write(rows)
       }
       this.autoRefresh_(true)
     }).catch((err) => {
+      if (this.focus.view !== view) {
+        return
+      }
       display.write(["Error", String(err), "", ""])
       // Re-arm on failure too, so a bad cycle can never permanently stop the
       // refresh loop (which previously stranded the view on a blank screen).


### PR DESCRIPTION
## Problem

Reported on a v3.0 board: with the LCD on **Station Stats**, pressing any button other than Back appears to return to the main menu — but then pressing Select on a different row (e.g. System) drops you back into Station Stats.

Both symptoms come from one split in the menu state machine. `select()` returns at `menu-manager.js:60-66` *before* `scroller.init()`, so entering a view leaves `MenuScroller` holding the **parent menu's rows** while `focus` moves to the view leaf:

- `up()`/`down()` moved the scroller and called `update_()`, which renders whatever rows the scroller holds — the parent list. The screen looked like it had gone back, but `focus` was still the view.
- The next `select()` tests `this.focus`, not the highlighted row. It matched `childCount() == 0 && view != null` at `menu-manager.js:52-57`, called `view_()`, and returned — re-rendering the view and ignoring the selection.

The nav stack also leaked an entry per bounce. **Every leaf view is affected** (Power, Server, Ip Address, …); Station Stats is simply the screen operators sit on, so it's the one that gets reported.

## Fix

- New `exitView_()`, called from `up()`/`down()`, pops `focus` so it matches the list already on screen. Deliberately no `scroller.init()` there — the scroller already holds the parent's rows and the operator's highlight, and re-initialising would snap it back to the first row mid-scroll. This preserves the *apparent* current behavior (Up/Down leaves the view) rather than making those buttons no-ops, since that's what operators are already trained on.
- Making Up/Down leave a view exposed a race in `view_()`: `results()` is async and slow tasks (Ping, or Station Stats at up to 3s per fetch) could resolve after navigation and paint their rows over the new menu. `view_()` now pins the view it was asked to render and drops the result if `focus.view` changed since. **That race already existed via `back()`** — this closes both.
- `src/station-lcd-interface/README.md` button-behavior table updated to match.

Behavior after the fix: Up/Down exit a view back to the menu it was launched from, keeping the highlight. Back also exits, but re-initialises the scroller (unchanged). Select inside a view still re-runs `results()` as a manual refresh.

## Verification

Reproduced and verified **on a v3.0 board (10.1.173.171)** by driving the real menu tree through the real `MenuManager` with only the display sink stubbed for a logger.

Before:

```
== SELECT (enter Station Stats)  focus=Station Stats | highlighted=Station Stats | stack=[English]
== DOWN    SCREEN: ["  Station Stats","> File Transfer","  Network","  System"]
           focus=Station Stats | highlighted=File Transfer | stack=[English]   <-- diverged
== SELECT  SCREEN: []                                                          <-- stats again
           focus=Station Stats | highlighted=File Transfer | stack=[English]
```

After:

```
== DOWN    focus=English       | highlighted=File Transfer | stack=[]
== SELECT  SCREEN: ["> Mount Usb","  Unmount Usb","  Download"]
           focus=File Transfer | highlighted=Mount Usb     | stack=[English]
== BACK    focus=English       | highlighted=Station Stats | stack=[]
```

Currently deployed on that board (checked out + `systemctl restart station-lcd-interface`): service `active`, `NRestarts: 0`, all four `gpio-keys` devices attached (`event0`–`event3`), hardware-server endpoints backing Station Stats returning 200.

## Notes for review

- **Base is `lts_26_07.iso`**, not `master` — that's the branch the fleet runs and where the bug is live.
- This branch therefore keeps `lts_26_07.iso`'s **unguarded** `autoRefresh_` (`this.focus.view.autoRefresh`, no null check); `web-wifi-manual-entry` has a guarded version. The fix doesn't newly expose that gap — `autoRefresh_(true)` is now only reachable from `view_`'s `.then`/`.catch` *after* the `focus.view !== view` early return, so `focus.view` is non-null there, and every other call site passes `false`. Happy to port the guard over as well if you'd prefer it on this base.
- **Physical button presses were not tested.** No `python3-evdev` on the station and `button-input.js` enumerates devices once at startup, so a synthetic `uinput` device wouldn't be seen. The state machine is verified on-board via the real code path, and the button→action mapping is confirmed from the kernel `KEY` bitmaps (`event0`=Back/`KEY_ESC`, `event1`=Select/`KEY_ENTER`, `event2`=Down/`KEY_DOWN`, `event3`=Up/`KEY_UP`). A press-the-buttons check at the panel is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)