### PR TITLE
fix(lcd): show IP for USB-ethernet dongles that don't enumerate as eth*

### DIFF
--- a/src/station-lcd-interface/tasks/ip-address-task.js
+++ b/src/station-lcd-interface/tasks/ip-address-task.js
@@ -10,7 +10,13 @@ class IpAddressTask {
   }
   results() {
     return new Promise((resolve, reject) => {
-      const regex = /(wlan\d+|eth\d+)/   // Match all 'eth' or 'wlan' interfaces
+      // Interfaces whose IP is worth showing on the front panel: wired (eth*),
+      // WiFi (wlan*), and USB-ethernet dongles that don't enumerate as eth* —
+      // predictable names (enx<mac>) or the legacy usb0. Anchored so we don't
+      // match virtual interfaces that merely contain "eth" (e.g. veth*), and
+      // deliberately NOT mdm0/ppp0 — the modem's 192.168.225.x is an internal
+      // point-to-point NAT, not a reachable address.
+      const regex = /^(eth\d+|wlan\d+|enx[0-9a-f]+|usb\d+)$/
       var ifaces = os.networkInterfaces()
 
       let rows = [this.header]
@@ -18,11 +24,13 @@ class IpAddressTask {
         if (key.match(regex)) {
           const result = value.filter(element => (element.family == 'IPv4') && (element.internal == false))
           result.forEach(element => {
-            if (key.includes('wlan')) {
+            // eth0-style names fit "name ip" on one row; wlan/enx/usb names can
+            // be long (enx<12 hex>), so give them their own row before the IP.
+            if (/^eth\d+$/.test(key)) {
+              rows.push(`${key} ${element.address}`)
+            } else {
               rows.push(`${key}`)
               rows.push(`${element.address}`)
-            } else {
-              rows.push(`${key} ${element.address}`)
             }
           })
         }


### PR DESCRIPTION
The front-panel IP screen matched only eth*/wlan*, so a USB-ethernet dongle enumerating as enx<mac> or usb0 showed a blank IP even with a valid address. Broaden the allowlist to eth*/wlan*/enx*/usb0 (anchored, so veth*/bridges that merely contain 'eth' are excluded), and keep the modem NAT (mdm0 192.168.225.x) and ppp0 off the screen. Long enx names get their own row before the IP, like wlan.