### PR TITLE
feat(scripts): collect-diagnostics on-station CLI + install-scripts OTA hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ regenerated from these entries.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`collect-diagnostics` is now an on-station CLI** (`/usr/local/sbin/collect-diagnostics`).
+  `system/scripts/collect-diagnostics.sh` gathers a read-only bundle — identity, hardware,
+  services, modem **+ SIM ICCID/IMSI**, and logs — as the `ctt` user (no sudo) and prints the
+  `.tar.gz` path. It is the single source of truth for what a diagnostic bundle contains; the
+  client-side SSH wrappers (Unix `.sh` / Windows `.ps1`, in the KB repo) become thin invokers.
+
+### Changed
+
+- **User-facing CLI symlinks are created by an OTA hook, not only by the Ansible image build.**
+  New `install-scripts.sh` (post-merge) symlinks the shell CLIs — `station-id`, `program-radios`,
+  `program-radio`, `update-station`, `bash-update-station`, `upload-station-data`,
+  `collect-diagnostics` — into `/usr/local/sbin`, so an OTA self-heals a lost symlink and an image
+  built without the legacy Ansible role still ships its CLIs. Moves CLI ownership into the
+  monorepo (retiring that slice of the Ansible boot-path debt). Runs in image-bake mode too.
+
+---
+
 ## [2.3.3] — 2026-07-30
 
 ### Fixed

--- a/system/scripts/collect-diagnostics.sh
+++ b/system/scripts/collect-diagnostics.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# collect-diagnostics — gather a sensor station's diagnostic bundle ON THIS STATION.
+#
+# Usage (SSH into the station first, then):  collect-diagnostics [dest-dir]
+#
+# Writes a read-only snapshot of identity, hardware, services, modem/SIM state and
+# logs to a .tar.gz (default under /tmp) and prints its path. Runs as the ctt user —
+# no sudo needed: ctt is in adm/video/i2c/dialout, so it can already read syslog,
+# vcgencmd, lsusb, mmcli -L/-m/-i, nmcli (non-secret fields), dmesg and /run/ctt/*.
+# Nothing on the station is modified.
+#
+# Client-side helpers that SSH in, run this, and pull the tarball back live in the
+# ctt-context-engineering repo (tools/collect-diagnostics.sh for Unix, .ps1 for
+# Windows) — this on-station collector is the single source of truth for WHAT is
+# collected; those wrappers just invoke it.
+set -u
+
+DEST="${1:-/tmp}"
+umask 077
+
+[ -r /run/ctt/board.env ] && . /run/ctt/board.env
+STATION_ID="${CTT_STATION_ID:-$(cat /etc/ctt/station-id 2>/dev/null)}"
+STATION_ID="$(printf '%s' "${STATION_ID:-$(hostname)}" | tr -cd 'A-Za-z0-9._-')"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="/tmp/ctt-diag-${STATION_ID}-${TS}"
+mkdir -p "$OUT"
+
+cap() { local f="$1"; shift; { echo "\$ $*"; "$@"; } >"$OUT/$f" 2>&1; }
+
+{ echo "station_id:    $STATION_ID"; echo "collected_utc: $TS"; echo
+  echo "== /run/ctt/board.env =="; cat /run/ctt/board.env 2>/dev/null
+  echo; echo "== /etc/ctt versions =="
+  for f in station-id station-image station-software station-board-revision station-revision; do
+    printf "%-26s %s\n" "$f" "$(cat "/etc/ctt/$f" 2>/dev/null)"; done
+} >"$OUT/00-identity.txt"
+
+# station run-config, raw (parameters only — no credentials live here)
+[ -r /etc/ctt/station-config.json ] && cp /etc/ctt/station-config.json "$OUT/00-station-config.json" 2>/dev/null
+
+cap 01-uname.txt          uname -a
+cap 01-os-release.txt     cat /etc/os-release
+cap 01-uptime.txt         uptime
+cap 01-throttled.txt      vcgencmd get_throttled      # 0x0=healthy; bit set = undervoltage/throttle
+cap 01-temp.txt           vcgencmd measure_temp
+cap 01-disk.txt           df -h
+cap 01-mem.txt            free -h
+
+cap 02-lsusb.txt          lsusb
+cap 02-lsusb-tree.txt     lsusb -t
+cap 02-serial-by-id.txt   ls -l /dev/serial/by-id/
+cap 02-serial-by-path.txt ls -l /dev/serial/by-path/
+
+cap 03-run-ctt-tree.txt   ls -laR /run/ctt
+for f in board.env sensors.json lcd leds modem-apn; do
+  [ -r "/run/ctt/$f" ] && cp "/run/ctt/$f" "$OUT/03-run-$f" 2>/dev/null; done
+command -v i2cdetect >/dev/null && cap 03-i2cdetect.txt i2cdetect -y 1
+
+cap 04-failed-units.txt   systemctl --failed --no-pager
+cap 04-ctt-units.txt      systemctl list-units --no-pager 'ctt*' 'station*' 'sensorgnome*' 'ModemManager*' 'NetworkManager*'
+
+# Modem / SIM: index the modem, then capture the modem, the SIM (ICCID/IMSI) and the bearer.
+MIDX="$(mmcli -L 2>/dev/null | grep -oE '/Modem/[0-9]+' | grep -oE '[0-9]+' | head -1)"
+cap 05-mmcli-L.txt        mmcli -L
+[ -n "$MIDX" ] && cap 05-mmcli-modem.txt mmcli -m "$MIDX"
+SIDX="$(mmcli -m "$MIDX" 2>/dev/null | grep -oE '/SIM/[0-9]+' | grep -oE '[0-9]+' | head -1)"
+[ -n "$MIDX" ] && [ -n "$SIDX" ] && cap 05-mmcli-sim.txt mmcli -m "$MIDX" -i "$SIDX"
+BIDX="$(mmcli -m "$MIDX" 2>/dev/null | grep -oE '/Bearer/[0-9]+' | grep -oE '[0-9]+' | head -1)"
+[ -n "$BIDX" ] && cap 05-mmcli-bearer.txt mmcli -b "$BIDX"
+cap 05-nmcli-dev.txt      nmcli -t -f DEVICE,TYPE,STATE d
+cap 05-nmcli-modem.txt    nmcli c show station-modem
+cap 05-ip-addr.txt        ip -br addr
+cap 05-ip-route.txt       ip route
+
+cap 06-dmesg.txt          dmesg -T   # note: pre-NTP boot lines may be mis-timestamped
+
+# pack: tar syslogs straight from /var/log (no copy -> safe on low disk / tmpfs)
+mkdir -p "$DEST" 2>/dev/null
+TARBALL="${DEST%/}/ctt-diag-${STATION_ID}-${TS}.tar.gz"
+SYSLOGS="$(cd /var/log && ls syslog* 2>/dev/null)"
+tar czf "$TARBALL" -C /tmp "$(basename "$OUT")" ${SYSLOGS:+-C /var/log $SYSLOGS}
+rm -rf "$OUT"
+
+echo "diagnostic bundle: $TARBALL"

--- a/system/scripts/hooks/post-merge.d/install-scripts.sh
+++ b/system/scripts/hooks/post-merge.d/install-scripts.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# install-scripts — symlink the user-facing shell CLIs from system/scripts/ into
+# /usr/local/sbin.
+#
+# These symlinks used to be created ONLY by the Ansible image build
+# (ctt-sensor-build/roles/configure-ctt-software); an OTA never (re)created them, so
+# a lost symlink — or an image built without the legacy Ansible role — left the
+# station with no CLIs. Listing them here makes an OTA self-heal them, the same
+# rationale as install-systemd.sh's MUST_BE_ENABLED for units, and moves CLI
+# ownership into the monorepo (retiring that slice of the Ansible boot-path debt).
+#
+# Unlike the network/udev deploys, this runs in image-bake mode too: a symlink needs
+# no NetworkManager/modem/hardware, so fresh images ship the CLIs and OTAs keep them.
+# The link targets the OTA checkout ($REPO), which is the same path in the bake and
+# on a running station.
+#
+# CLIs run as the ctt user where the command allows it (ctt is in adm/video/i2c/dialout).
+#
+# Must run as root: writes to /usr/local/sbin.
+
+set -e
+
+source "${CTT_HOOK_LIB:-$(dirname "$(readlink -f "$0")")/../_lib.sh}"
+require_root
+
+REPO="${REPO:-/usr/lib/ctt/sensor-station-software}"
+SRC_DIR="$REPO/system/scripts"
+BIN_DIR="${BIN_DIR:-/usr/local/sbin}"
+
+# CLI command  ->  script in system/scripts/. Add new commands here.
+CLIS="
+station-id            station-id.sh
+program-radios        program-radios.sh
+program-radio         program-radio.sh
+update-station        update-station.sh
+bash-update-station   bash-update-station.sh
+upload-station-data   upload-station-data.sh
+collect-diagnostics   collect-diagnostics.sh
+"
+
+mkdir -p "$BIN_DIR"
+changed=0
+while read -r name script; do
+  [ -z "$name" ] && continue
+  src="$SRC_DIR/$script"
+  dst="$BIN_DIR/$name"
+  if [ ! -f "$src" ]; then
+    log_warn "CLI source missing: $src — skipping '$name'"
+    continue
+  fi
+  # -f replaces a stale link or a regular file left by an older image; -n so an
+  # existing dir symlink is replaced, not descended into.
+  if [ "$(readlink -f "$dst" 2>/dev/null)" != "$(readlink -f "$src")" ]; then
+    ln -sfn "$src" "$dst"
+    log_info "linked $dst -> $src"
+    changed=1
+  fi
+done <<EOF
+$CLIS
+EOF
+
+[ "$changed" = 0 ] && log_info "all CLI symlinks already current"
+exit 0


### PR DESCRIPTION
Graduates the diagnostic collector into the monorepo as an **on-station CLI**, and moves user-facing CLI symlinks off Ansible onto an OTA hook (option B from our discussion).

## What
- **`system/scripts/collect-diagnostics.sh`** — on-station collector. Read-only bundle (identity, hardware, services, modem **+ SIM ICCID/IMSI**, logs) as the `ctt` user, **no sudo**; prints the `.tar.gz` path. Single source of truth for what a bundle contains — the KB-side SSH wrappers (Unix `.sh` / Windows `.ps1`) become thin invokers. Adds `mmcli -i` SIM capture, closing the gap where the ICCID had to be dug out of syslog.
- **`install-scripts.sh`** (post-merge hook) — symlinks the shell CLIs (`station-id`, `program-radios`, `program-radio`, `update-station`, `bash-update-station`, `upload-station-data`, `collect-diagnostics`) into `/usr/local/sbin`. An OTA now self-heals a lost symlink

## Why
CLI symlinks were created only by the Ansible image build — an OTA never (re)created them, so a lost symlink or an Ansible-free image had no CLIs. Same self-healing rationale as Finding A gave the units, and it retires a slice of the Ansible→monorepo boot-path debt. Useful now for the manual-image-modify / support workflow: any station can `collect-diagnostics` itself.

## Validation
- Hook creates all **7 symlinks** and is **idempotent** (tested against a temp `BIN_DIR` with the real repo).
- Exec bits correct: collector `100755` (run directly), hook `100644` (bash-invoked, matches the other hooks).
- Collector **run on a real station as `ctt`, no sudo** → 207 KB bundle, and `05-mmcli-sim.txt` captured `iccid 8946…` / `imsi 24008…` / `TelenorS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)